### PR TITLE
feat/Upload file to S3 using presigned url and get file from cloudfront (not using presigned url)

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -60,6 +60,10 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation group: 'org.javassist', name: 'javassist', version: '3.15.0-GA'
+
+    //AWS SDK for Java 1.x
+    implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.529')
+    implementation 'com.amazonaws:aws-java-sdk-s3'
 }
 
 tasks.named('test') {

--- a/demo/src/main/java/com/example/demo/config/S3Config.java
+++ b/demo/src/main/java/com/example/demo/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.example.demo.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.aws_access_key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.aws_secret_key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        //자격 증명
+
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/demo/src/main/java/com/example/demo/config/S3Uploader.java
+++ b/demo/src/main/java/com/example/demo/config/S3Uploader.java
@@ -1,0 +1,64 @@
+package com.example.demo.config;
+
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class S3Uploader {
+
+    @Autowired
+    private S3Config s3Config;
+
+    @Value("${cloud.aws.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.cloudfront.path}")
+    private String cloudfrontPath;
+
+    private final int PRESIGNED_URL_EXPIRATION = 60 * 1000; // 1분
+
+
+    public String getPresignedUrl(String fileName) {
+        return generatePresignedUrl(fileName).toString();
+    }
+
+
+    // Upload file to S3 using presigned url
+    private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String fileName) {
+        return new GeneratePresignedUrlRequest(bucket, "test/" + fileName)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(setExpiration());
+    }
+
+    private URL generatePresignedUrl(String fileName) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(fileName);
+        URL url = s3Config.amazonS3().generatePresignedUrl(generatePresignedUrlRequest);
+        return url;
+    }
+
+    private Date setExpiration(){
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += PRESIGNED_URL_EXPIRATION;
+        expiration.setTime(expTimeMillis);
+        return expiration;
+    }
+
+    private String getUniqueFilename(String fileName) {
+        String uuid = UUID.randomUUID().toString();
+        return "test/" + fileName + uuid;
+    }
+
+    //get file from cloudfront not using presigned url
+    private String getCloudfrontFilePath(String fileName) {
+        return cloudfrontPath + fileName;
+    }
+}

--- a/demo/src/main/resources/application.yml
+++ b/demo/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
     url: jdbc:mysql://localhost:3306/dears?createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
     #  url: jdbc:mysql://localhost:8080/everytime?createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul?useSSL=false
     username: root
-    password: Jyh0914@
+    password: ${LOCAL_DB_PS:Jyh0914@}
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
### PR 요약
- 이미지 업로드 시 Front는 Server에서 Presigned Url을 받아와 할당된 만료 시간(1분) 내에 S3 버킷으로 이미지를 PUT할 수 있습니다.
- 이미지 GET 요청 시에는 cloudfront URL로 바로 받아옵니다. ex. http:/{cloudfrontDNS}/{버킷폴더}/{imageUrl}
- 이 때 이미지 경로는 버킷 속에서 각각 유일해야 하므로 uuid를 포함하여 DB에 저장할 예정입니다.

### 변경 사항
- @Value 어노테이션 으로 지정된 환경변수의 경우에는 **Elastic Beanstalk 환경변수에 설정**해두었습니다. (따로 설정 필요x
- 이미지 업로드를 위해 AWS **S3/Cloudfront/IAM 설정**

### 참고 사항
- 노션 링크에 상세한 설명 추가하겠습니다.
- Local 에서 작업 시 IntelliJ에 S3 환경변수 추가해주세요.(노션 참고)