### PR TITLE
feat/add method to get current authenticated member from securitycontext

### DIFF
--- a/demo/src/main/java/com/example/demo/config/SwaggerConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.example.demo.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,8 +13,16 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Bearer Token");
+
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components().addSecuritySchemes("Bearer Token", bearerAuth))
+                .addSecurityItem(securityRequirement)
                 .info(apiInfo());
     }
 

--- a/demo/src/main/java/com/example/demo/member/controller/MemberController.java
+++ b/demo/src/main/java/com/example/demo/member/controller/MemberController.java
@@ -6,10 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/demo/src/main/java/com/example/demo/member/domain/Member.java
+++ b/demo/src/main/java/com/example/demo/member/domain/Member.java
@@ -1,8 +1,10 @@
 package com.example.demo.member.domain;
 
 import com.example.demo.enums.member.MemberRole;
+import com.example.demo.wishlist.domain.WishList;
 import jakarta.persistence.*;
 import lombok.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -23,4 +25,6 @@ public class Member {
     @Column //중복x, nullx, 멤버 구분자
     private String name;
 
+    @OneToMany(mappedBy = "member")
+    private List<WishList> wishList;
 }

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -7,16 +7,21 @@ import com.example.demo.member.dto.MemberAuthDTO;
 import com.example.demo.member.mapper.MemberMapper;
 import com.example.demo.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -46,5 +51,14 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .name(UUID.randomUUID().toString()).build();
         memberRepository.save(member);
         return memberMapper.entityToResponse(member);
+    }
+
+    public Optional<Member> getCurrentAuthenticatedMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated() && !(authentication instanceof AnonymousAuthenticationToken)) {
+            String memberName = authentication.getName();
+            return memberRepository.findByName(memberName);
+        }
+        throw new UsernameNotFoundException("인증된 사용자를 찾을 수 없습니다.");
     }
 }

--- a/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioOverviewDTO.java
+++ b/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioOverviewDTO.java
@@ -1,0 +1,2 @@
+package com.example.demo.portfolio.dto;public class PortfolioOverviewDTO {
+}

--- a/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
+++ b/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
@@ -1,0 +1,2 @@
+package com.example.demo.wishlist.controller;public class WishListController {
+}

--- a/demo/src/main/java/com/example/demo/wishlist/domain/WishList.java
+++ b/demo/src/main/java/com/example/demo/wishlist/domain/WishList.java
@@ -1,0 +1,29 @@
+package com.example.demo.wishlist.domain;
+
+import com.example.demo.member.domain.Member;
+import com.example.demo.portfolio.domain.Portfolio;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class WishList {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "wishlist_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "portfolio_id")
+    private Portfolio portfolio;
+
+
+}

--- a/demo/src/main/java/com/example/demo/wishlist/dto/WishListDto.java
+++ b/demo/src/main/java/com/example/demo/wishlist/dto/WishListDto.java
@@ -1,0 +1,2 @@
+package com.example.demo.wishlist.dto;public class WishListDto {
+}

--- a/demo/src/main/java/com/example/demo/wishlist/repository/WishListRepository.java
+++ b/demo/src/main/java/com/example/demo/wishlist/repository/WishListRepository.java
@@ -1,0 +1,2 @@
+package com.example.demo.wishlist.repository;public class WishListRepository {
+}

--- a/demo/src/main/java/com/example/demo/wishlist/service/WishListService.java
+++ b/demo/src/main/java/com/example/demo/wishlist/service/WishListService.java
@@ -1,0 +1,2 @@
+package com.example.demo.wishlist.service;public class WishListService {
+}

--- a/demo/src/test/java/com/example/demo/portfolio/PortfolioRepositoryTest.java
+++ b/demo/src/test/java/com/example/demo/portfolio/PortfolioRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.example.demo.portfolio;
+
+import com.example.demo.portfolio.domain.Portfolio;
+import com.example.demo.portfolio.repository.PortfolioRepository;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+@DataJpaTest //JPA Repository들에 대한 빈 등록하여 테스트 가능
+@DisplayName("Portfolio Test")
+@Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class PortfolioRepositoryTest {
+
+    @Autowired
+    private PortfolioRepository portfolioRepository;
+
+
+    @Before
+    void setUp() {
+
+    }
+
+    @Test
+    @DisplayName("포트폴리오 전체 조회 테스트")
+    void findAllByPage() {
+        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by("id").ascending());
+
+        Page<Portfolio> portfolios = portfolioRepository.findAll(pageRequest);
+
+        //junit
+        Assertions.assertThat(portfolios.getSize()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
### PR 요약
- SecurityContext에서 현재 인증된 멤버를 가져오는 메소드 추가
- Swagger에 Authorization Header를 넣어 사용할 수 있도록 수정

### 변경 사항
![image](https://github.com/dears-swm-15th/dears-core-api/assets/81344634/06a60991-a7b0-4dc4-bcb7-a9dc6c22f2a1)
위 사진에서 Authorize 버튼을 사용하여 Header에 `Authorization Bearer {UUID}` 의 요청을 추가할 수 있습니다. 
DataLoader를 사용하여 아래와 같이 테스트해볼 수 있도록 구현해 두었습니다.
-> UUID에 Clara, Jeff를 기입하면 Customer로, Tom을 기입하면 WeddingPlanner 권한으로 접근 가능

### 참고 사항
`getCurrentAuthenticatedMember()` 메소드를 통해 필터링으로 들어온 SpringContext 속 Member의 정보를 꺼내올 수 있습니다. `Authorization Bearer {UUID}` 로 접근한 요청들에 대해 `getCurrentAuthenticatedMember()` 메소드를 호출하면 parameter 값 없이 Member 정보를 가져올 수 있습니다.