### PR TITLE
Feat/wishlist

### DIFF
--- a/demo/src/main/java/com/example/demo/dummy/DataLoader.java
+++ b/demo/src/main/java/com/example/demo/dummy/DataLoader.java
@@ -69,6 +69,7 @@ public class DataLoader implements CommandLineRunner {
                 .services(services1)
                 .weddingPhotoUrls(weddingPhotos1)
                 .avgRadar(radar1)
+                .wishListCount(0)
                 .build();
 
         Portfolio portfolio2 = Portfolio.builder()
@@ -85,6 +86,7 @@ public class DataLoader implements CommandLineRunner {
                 .services(services2)
                 .weddingPhotoUrls(weddingPhotos2)
                 .avgRadar(radar2)
+                .wishListCount(0)
                 .build();
 
         portfolioRepository.save(portfolio1);

--- a/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
+++ b/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
@@ -3,6 +3,7 @@ package com.example.demo.portfolio.domain;
 import com.example.demo.base.BaseTimeEntity;
 import com.example.demo.enums.review.RadarKey;
 import com.example.demo.enums.portfolio.Region;
+import com.example.demo.wishlist.domain.WishList;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Where;
@@ -57,6 +58,8 @@ public class Portfolio extends BaseTimeEntity {
     @Column(name = "radar_value")
     private Map<RadarKey, Float> avgRadar;
 
+    @OneToMany(mappedBy = "portfolio")
+    private List<WishList> wishList;
 
 }
 

--- a/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
+++ b/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
@@ -3,7 +3,6 @@ package com.example.demo.portfolio.domain;
 import com.example.demo.base.BaseTimeEntity;
 import com.example.demo.enums.review.RadarKey;
 import com.example.demo.enums.portfolio.Region;
-import com.example.demo.wishlist.domain.WishList;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Where;
@@ -58,8 +57,13 @@ public class Portfolio extends BaseTimeEntity {
     @Column(name = "radar_value")
     private Map<RadarKey, Float> avgRadar;
 
-    @OneToMany(mappedBy = "portfolio")
-    private List<WishList> wishList;
+    private Integer wishListCount;
 
+    public void addWishListCount() {
+        if (this.wishListCount == null) {
+            this.wishListCount = 0;
+        }
+        this.wishListCount++;
+    }
 }
 

--- a/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioOverviewDTO.java
+++ b/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioOverviewDTO.java
@@ -1,0 +1,48 @@
+package com.example.demo.portfolio.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+
+public class PortfolioOverviewDTO {
+
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+
+        @Schema(type = "Long", example = "1")
+        private Long portfolioId;
+    }
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        @Schema(type = "Long", example = "1")
+        private Long id;
+
+        @Schema(type = "string", example = "에바웨딩스")
+        private String organization;
+
+        @Schema(type = "string", example = "김지수")
+        private String plannerName;
+
+        @Schema(type = "string", example = "GANGNAM")
+        private String region;
+
+        @Schema(type = "string", example = "src/wedding_planner/imgs")
+        private String profileImageUrl;
+
+        @Schema(type = "integer", example = "20000")
+        private Integer minEstimate;
+    }
+
+}

--- a/demo/src/main/java/com/example/demo/portfolio/mapper/PortfolioMapper.java
+++ b/demo/src/main/java/com/example/demo/portfolio/mapper/PortfolioMapper.java
@@ -2,6 +2,7 @@ package com.example.demo.portfolio.mapper;
 
 import com.example.demo.portfolio.domain.Portfolio;
 import com.example.demo.portfolio.dto.PortfolioDTO;
+import com.example.demo.portfolio.dto.PortfolioOverviewDTO;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -21,4 +22,6 @@ public interface PortfolioMapper {
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "id", ignore = true)
     Portfolio updateFromRequest(PortfolioDTO.Request portfolioRequest, @MappingTarget Portfolio portfolio);
+
+    PortfolioOverviewDTO.Response entityToOverviewResponse(Portfolio portfolio);
 }

--- a/demo/src/main/java/com/example/demo/portfolio/repository/PortfolioRepository.java
+++ b/demo/src/main/java/com/example/demo/portfolio/repository/PortfolioRepository.java
@@ -1,17 +1,25 @@
 package com.example.demo.portfolio.repository;
 
 import com.example.demo.portfolio.domain.Portfolio;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.swing.text.html.Option;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Portfolio p where p.id = :id")
+    Optional<Portfolio> findPortfolioByIdWithPessimisticLock(Long id);
 
     @Transactional
     @Modifying

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -119,4 +119,12 @@ public class PortfolioService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public Portfolio addWishListCount(Long id) {
+        Portfolio portfolio = portfolioRepository.findPortfolioByIdWithPessimisticLock(id)
+                .orElseThrow(() -> new RuntimeException("Portfolio not found"));
+        portfolio.addWishListCount();
+        portfolioRepository.save(portfolio);
+        return portfolio;
+    }
 }

--- a/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
+++ b/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
@@ -21,7 +21,7 @@ public class WishListController {
     private final WishListService wishListService;
 
     @GetMapping("")
-    @Operation(summary = "위시리스트 목록 조회")
+    @Operation(summary = "위시리스트 목록 조회", description = "자신의 위시리스트 목록을 조회합니다.")
     public ResponseEntity<List<PortfolioOverviewDTO.Response>> getWishListByMember(@RequestParam(value = "page", defaultValue = "0") int page,
                                                                             @RequestParam(value = "size", defaultValue = "10") int size){
         List<PortfolioOverviewDTO.Response> portfolioOverviews = wishListService.getWishListByMember(page, size);
@@ -29,7 +29,7 @@ public class WishListController {
     }
 
     @PostMapping("")
-    @Operation(summary = "위시리스트 추가")
+    @Operation(summary = "위시리스트 추가", description = "자신이 원하는 포트폴리오를 위시리스트에 추가합니다.")
     public ResponseEntity<Void> addWishList(@RequestBody WishListDto.Request request){
         wishListService.addWishList(request);
         return ResponseEntity.ok().build();

--- a/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
+++ b/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
@@ -1,0 +1,37 @@
+package com.example.demo.wishlist.controller;
+
+import com.example.demo.portfolio.dto.PortfolioOverviewDTO;
+import com.example.demo.wishlist.dto.WishListDto;
+import com.example.demo.wishlist.service.WishListService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/wishlist")
+@Tag(name = "wishlist", description = "wishlist API")
+public class WishListController {
+
+    private final WishListService wishListService;
+
+    @GetMapping("")
+    @Operation(summary = "위시리스트 목록 조회")
+    public ResponseEntity<List<PortfolioOverviewDTO.Response>> getWishListByMember(@RequestParam(value = "page", defaultValue = "0") int page,
+                                                                            @RequestParam(value = "size", defaultValue = "10") int size){
+        List<PortfolioOverviewDTO.Response> portfolioOverviews = wishListService.getWishListByMember(page, size);
+        return ResponseEntity.ok(portfolioOverviews);
+    }
+
+    @PostMapping("")
+    @Operation(summary = "위시리스트 추가")
+    public ResponseEntity<Void> addWishList(@RequestBody WishListDto.Request request){
+        wishListService.addWishList(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/demo/src/main/java/com/example/demo/wishlist/domain/WishList.java
+++ b/demo/src/main/java/com/example/demo/wishlist/domain/WishList.java
@@ -1,0 +1,28 @@
+package com.example.demo.wishlist.domain;
+
+import com.example.demo.base.BaseTimeEntity;
+import com.example.demo.member.domain.Member;
+import com.example.demo.portfolio.domain.Portfolio;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class WishList extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "wishlist_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "portfolio_id")
+    private Portfolio portfolio;
+}

--- a/demo/src/main/java/com/example/demo/wishlist/dto/WishListDto.java
+++ b/demo/src/main/java/com/example/demo/wishlist/dto/WishListDto.java
@@ -1,0 +1,29 @@
+package com.example.demo.wishlist.dto;
+
+import com.example.demo.portfolio.domain.Portfolio;
+import lombok.*;
+
+import java.util.List;
+
+public class WishListDto {
+
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private Long portfolioId;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        List<Portfolio> portfolios;
+    }
+}

--- a/demo/src/main/java/com/example/demo/wishlist/repository/WishListRepository.java
+++ b/demo/src/main/java/com/example/demo/wishlist/repository/WishListRepository.java
@@ -1,0 +1,18 @@
+package com.example.demo.wishlist.repository;
+
+import com.example.demo.wishlist.domain.WishList;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WishListRepository extends JpaRepository<WishList, Long> {
+
+    Page<WishList> findAllByMemberId(Long memberId, Pageable pageable);
+
+    @Query("SELECT COUNT(w) FROM WishList w WHERE w.portfolio = :portfolioId")
+    long countByPortfolioId(@Param("portfolioId") Long portfolioId);
+}

--- a/demo/src/main/java/com/example/demo/wishlist/service/WishListService.java
+++ b/demo/src/main/java/com/example/demo/wishlist/service/WishListService.java
@@ -5,7 +5,7 @@ import com.example.demo.member.service.CustomUserDetailsService;
 import com.example.demo.portfolio.domain.Portfolio;
 import com.example.demo.portfolio.dto.PortfolioOverviewDTO;
 import com.example.demo.portfolio.mapper.PortfolioMapper;
-import com.example.demo.portfolio.repository.PortfolioRepository;
+import com.example.demo.portfolio.service.PortfolioService;
 import com.example.demo.wishlist.domain.WishList;
 import com.example.demo.wishlist.dto.WishListDto;
 import com.example.demo.wishlist.repository.WishListRepository;
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -22,7 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WishListService {
 
-    private final PortfolioRepository portfolioRepository;
+    private final PortfolioService portfolioService;
     private final CustomUserDetailsService memberService;
     private final WishListRepository wishListRepository;
     private final PortfolioMapper portfolioMapper;
@@ -38,9 +39,10 @@ public class WishListService {
         return portfolioOverviewDtos;
     }
 
+    @Transactional
     public void addWishList(WishListDto.Request request) {
         Member member = memberService.getCurrentAuthenticatedMember().orElseThrow();
-        Portfolio portfolio = portfolioRepository.findById(request.getPortfolioId()).orElseThrow();
+        Portfolio portfolio = portfolioService.addWishListCount(request.getPortfolioId());
         WishList wishList = WishList.builder()
                 .member(member)
                 .portfolio(portfolio)

--- a/demo/src/main/java/com/example/demo/wishlist/service/WishListService.java
+++ b/demo/src/main/java/com/example/demo/wishlist/service/WishListService.java
@@ -1,0 +1,50 @@
+package com.example.demo.wishlist.service;
+
+import com.example.demo.member.domain.Member;
+import com.example.demo.member.service.CustomUserDetailsService;
+import com.example.demo.portfolio.domain.Portfolio;
+import com.example.demo.portfolio.dto.PortfolioOverviewDTO;
+import com.example.demo.portfolio.mapper.PortfolioMapper;
+import com.example.demo.portfolio.repository.PortfolioRepository;
+import com.example.demo.wishlist.domain.WishList;
+import com.example.demo.wishlist.dto.WishListDto;
+import com.example.demo.wishlist.repository.WishListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class WishListService {
+
+    private final PortfolioRepository portfolioRepository;
+    private final CustomUserDetailsService memberService;
+    private final WishListRepository wishListRepository;
+    private final PortfolioMapper portfolioMapper;
+
+    public List<PortfolioOverviewDTO.Response> getWishListByMember(int page, int size) {
+        Long memberId = memberService.getCurrentAuthenticatedMember().orElseThrow().getId();
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt").ascending());
+        Page<WishList> wishLists = wishListRepository.findAllByMemberId(memberId, pageRequest);
+        List<PortfolioOverviewDTO.Response> portfolioOverviewDtos = wishLists.stream()
+                .map(wishList -> portfolioMapper.entityToOverviewResponse(wishList.getPortfolio()))
+                .toList();
+
+        return portfolioOverviewDtos;
+    }
+
+    public void addWishList(WishListDto.Request request) {
+        Member member = memberService.getCurrentAuthenticatedMember().orElseThrow();
+        Portfolio portfolio = portfolioRepository.findById(request.getPortfolioId()).orElseThrow();
+        WishList wishList = WishList.builder()
+                .member(member)
+                .portfolio(portfolio)
+                .build();
+        wishListRepository.save(wishList);
+    }
+}

--- a/demo/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/demo/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -3,6 +3,10 @@ package com.example.demo;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 //@SpringBootTest
 class DemoApplicationTests {
 

--- a/demo/src/test/java/com/example/demo/portfolio/PortfolioConcurrencyTest.java
+++ b/demo/src/test/java/com/example/demo/portfolio/PortfolioConcurrencyTest.java
@@ -1,0 +1,84 @@
+package com.example.demo.portfolio;
+
+import com.example.demo.config.S3Config;
+import com.example.demo.config.S3Uploader;
+import com.example.demo.portfolio.domain.Portfolio;
+import com.example.demo.portfolio.repository.PortfolioRepository;
+import com.example.demo.portfolio.service.PortfolioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.testng.Assert.assertEquals;
+
+@SpringBootTest
+public class PortfolioConcurrencyTest {
+
+
+    @MockBean
+    private S3Uploader s3Uploader;
+
+    @MockBean
+    private S3Config s3Config;
+
+
+    @Autowired
+    private PortfolioRepository portfolioRepository;
+
+    @Autowired
+    private PortfolioService portfolioService;
+
+    private Portfolio portfolio;
+
+    @BeforeEach
+    public void before() {
+        portfolio = portfolioRepository.findById(1L).orElseThrow();
+    }
+
+    @Test
+    public void 텀을_두고_100개_요청() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            Thread.sleep(100);
+            executorService.submit(() -> {
+                try {
+                    portfolioService.addWishListCount(portfolio.getId());
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        Portfolio updatedPortfolio = portfolioRepository.findById(portfolio.getId()).orElseThrow();
+        assertEquals(updatedPortfolio.getWishListCount(), 100);
+    }
+
+    @Test
+    public void 동시에_100개_요청() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    portfolioService.addWishListCount(1L);
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        Portfolio updatedPortfolio = portfolioRepository.findById(portfolio.getId()).orElseThrow();
+        assertEquals(updatedPortfolio.getWishListCount(), 100);
+    }
+}

--- a/demo/src/test/java/com/example/demo/portfolio/PortfolioRepositoryTest.java
+++ b/demo/src/test/java/com/example/demo/portfolio/PortfolioRepositoryTest.java
@@ -1,0 +1,41 @@
+package com.example.demo.portfolio;
+
+import com.example.demo.portfolio.domain.Portfolio;
+import com.example.demo.portfolio.repository.PortfolioRepository;
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+@DataJpaTest //JPA Repository들에 대한 빈 등록하여 테스트 가능
+@DisplayName("Portfolio Test")
+@Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class PortfolioRepositoryTest {
+
+    @Autowired
+    private PortfolioRepository portfolioRepository;
+
+
+    @Before
+    void setUp() {
+    }
+
+    @Test
+    @DisplayName("포트폴리오 전체 조회 테스트")
+    void findAllByPage() {
+        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by("id").ascending());
+
+        Page<Portfolio> portfolios = portfolioRepository.findAll(pageRequest);
+
+        //junit
+        Assertions.assertThat(portfolios.getSize()).isEqualTo(1);
+    }
+}

--- a/demo/src/test/java/com/example/demo/portfolio/PortfolioRepositoryTest.java
+++ b/demo/src/test/java/com/example/demo/portfolio/PortfolioRepositoryTest.java
@@ -29,7 +29,7 @@ public class PortfolioRepositoryTest {
     }
 
     @Test
-    @DisplayName("포트폴리오 전체 조회 테스트")
+    @DisplayName("Pagination을 활용하여 포트폴리오 리스트를 조회")
     void findAllByPage() {
         PageRequest pageRequest = PageRequest.of(0, 1, Sort.by("id").ascending());
 

--- a/demo/src/test/java/com/example/demo/wishlist/WishListTest.java
+++ b/demo/src/test/java/com/example/demo/wishlist/WishListTest.java
@@ -1,0 +1,101 @@
+package com.example.demo.wishlist;
+
+
+import com.example.demo.config.S3Config;
+import com.example.demo.config.S3Uploader;
+import com.example.demo.enums.member.MemberRole;
+import com.example.demo.member.domain.Member;
+import com.example.demo.member.repository.MemberRepository;
+import com.example.demo.member.service.CustomUserDetailsService;
+import com.example.demo.portfolio.domain.Portfolio;
+import com.example.demo.portfolio.repository.PortfolioRepository;
+import com.example.demo.wishlist.domain.WishList;
+import com.example.demo.wishlist.dto.WishListDto;
+import com.example.demo.wishlist.repository.WishListRepository;
+import com.example.demo.wishlist.service.WishListService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+import static org.testng.Assert.assertEquals;
+
+@SpringBootTest
+@Transactional
+public class WishListTest {
+
+    @MockBean
+    private S3Uploader s3Uploader;
+
+    @MockBean
+    private S3Config s3Config;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PortfolioRepository portfolioRepository;
+
+    @Autowired
+    private WishListService wishListService;
+
+    @Autowired
+    private WishListRepository wishListRepository;
+
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    @BeforeEach
+    public void before() {
+
+        // 임시 사용자 생성 및 인증 설정
+        Member member = new Member(1L, MemberRole.CUSTOMER, "test");
+        UserDetails userDetails = new User(
+                member.getName(),
+                "password",
+                Collections.singletonList(new SimpleGrantedAuthority(member.getRole().getRoleName()))
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, "password", userDetails.getAuthorities())
+        );
+        memberRepository.saveAndFlush(member);
+
+        Member member1 = memberRepository.findById(1L).orElseThrow();
+        Member member2 = memberRepository.findById(2L).orElseThrow();
+        Portfolio portfolio1 = portfolioRepository.findById(1L).orElseThrow();
+        Portfolio portfolio2 = portfolioRepository.findById(2L).orElseThrow();
+
+        wishListRepository.saveAndFlush(WishList.builder()
+                .member(member1)
+                .portfolio(portfolio1)
+                .build());
+    }
+
+    @AfterEach
+    public void after() {
+        wishListRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("WishList_등록_시_Portfolio_WishListCount_증가")
+    public void WishList_등록_시_Portfolio_WishListCount_증가() {
+        wishListService.addWishList(WishListDto.Request.builder()
+                .portfolioId(1L)
+                .build());
+
+        assertEquals(1, wishListRepository.findById(1L).orElseThrow().getPortfolio().getWishListCount());
+    }
+
+}


### PR DESCRIPTION
### PR 요약
포트폴리오를 wishlist에 등록하는 로직 추가, 비관적락을 사용하여 동시성 문제 해결
포트폴리오 리스트를 pagination 형태로 받아오는 로직

### 변경 사항
Portfolio Entity에 wishListCount 컬럼을 추가하였습니다.

아래 두 API가 추가되었습니다.
- Member가 자신의 portfolio wishList를 가져오는 get메소드
- Member가 원하는 portfolio 를 찜하는 post메소드

### 참고 사항
동시성 문제의 경우 비관적 락을 선택하여 해결하였습니다.(설명은 Notion 참고)
이후 분산환경(EC2 autoscaling)의 가능성을 고려하여 Named Lock이나 Redis를 활용해볼 예정입니다.
현재 CI에서 Test 환경 Mysql DB 오류가 나는데 해결하여 올리겠습니다 !