### PR TITLE
feat/get customer&weddingplanner mypage

### DIFF
--- a/demo/.platform/nginx/nginx.conf
+++ b/demo/.platform/nginx/nginx.conf
@@ -7,7 +7,6 @@ worker_rlimit_nofile    33282;
 events {
     use epoll;
     worker_connections  1024;
-    multi_accept on;
 }
 
 http {
@@ -31,7 +30,6 @@ http {
 
   server {
       listen        80 default_server;
-      listen        [::]:80 default_server;
 
       location / {
           proxy_pass          http://springboot;
@@ -52,7 +50,6 @@ http {
       gzip                  off;
       gzip_comp_level       4;
 
-      # Include the Elastic Beanstalk generated locations
       include conf.d/elasticbeanstalk/healthd.conf;
   }
 }

--- a/demo/src/main/java/com/example/demo/dummy/DataLoader.java
+++ b/demo/src/main/java/com/example/demo/dummy/DataLoader.java
@@ -119,7 +119,7 @@ public class DataLoader implements CommandLineRunner {
         reviewRadar2.put(RadarKey.SCHEDULE_COMPLIANCE, 4.5f);
 
         Review review1 = Review.builder()
-                .reviewerName("Alice")
+                .reviewerId(1L)
                 .content("Great experience with Organization One. Highly recommend!")
                 .isProvided(true)
                 .rating(4.5f)
@@ -130,7 +130,7 @@ public class DataLoader implements CommandLineRunner {
                 .build();
 
         Review review2 = Review.builder()
-                .reviewerName("Bob")
+                .reviewerId(1L)
                 .content("Organization Two provided excellent service. Very satisfied!")
                 .isProvided(false)
                 .rating(4.6f)
@@ -157,7 +157,7 @@ public class DataLoader implements CommandLineRunner {
 
         WeddingPlanner member3 = WeddingPlanner.builder()
                 .name("Alice")
-                .UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")
+                .UUID("b1b3825f-304f-4bce-b3b7-91b70fe79cb7")
                 .role(WEDDING_PLANNER)
                 .build();
 

--- a/demo/src/main/java/com/example/demo/member/controller/MemberController.java
+++ b/demo/src/main/java/com/example/demo/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.demo.member.controller;
 
-import com.example.demo.member.dto.AuthDTO;
+import  com.example.demo.member.dto.AuthDTO;
+import com.example.demo.member.dto.MypageDTO;
 import com.example.demo.member.service.CustomUserDetailsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,4 +23,19 @@ public class MemberController {
         AuthDTO.Response createdMember = customUserDetailsService.join(customerAuthRequest.getRole());
         return ResponseEntity.status(201).body(createdMember);
     }
+
+    @GetMapping("/customer/mypage")
+    @Operation(summary = "유저 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")
+    public ResponseEntity<MypageDTO.CustomerResponse> getCustomerMyPage(){
+        MypageDTO.CustomerResponse myPage = customUserDetailsService.getCustomerMyPage();
+        return ResponseEntity.status(200).body(myPage);
+    }
+
+    @GetMapping("/weddingplanner/mypage")
+    @Operation(summary = "웨딩플래너 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")
+    public ResponseEntity<MypageDTO.WeddingPlannerResponse> getWeddingPlannerMyPage(){
+        MypageDTO.WeddingPlannerResponse myPage = customUserDetailsService.getWeddingPlannerMyPage();
+        return ResponseEntity.status(200).body(myPage);
+    }
+
 }

--- a/demo/src/main/java/com/example/demo/member/dto/AuthDTO.java
+++ b/demo/src/main/java/com/example/demo/member/dto/AuthDTO.java
@@ -27,7 +27,7 @@ public class AuthDTO {
         @Schema(type = "string", example = "ROLE_USER")
         private String role;
         @Schema(type = "string", example = "84f6cd04-9985-4da6-94b5-e79fffd88e61")
-        private String name;
+        private String UUID;
     }
 
 }

--- a/demo/src/main/java/com/example/demo/member/dto/MypageDTO.java
+++ b/demo/src/main/java/com/example/demo/member/dto/MypageDTO.java
@@ -1,0 +1,37 @@
+package com.example.demo.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class MypageDTO {
+
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CustomerResponse {
+
+        @Schema(type = "string", example = "84f6cd04-9985-4da6-94b5-e79fffd88e61")
+        private String name;
+        @Schema(type = "string", example = "https://s3.ap-northeast-2.amazonaws.com/sopt-27th/profile/84f6cd04-9985-4da6-94b5-e79fffd88e61")
+        private String profileImageUrl;
+
+    }
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class WeddingPlannerResponse {
+
+        @Schema(type = "string", example = "84f6cd04-9985-4da6-94b5-e79fffd88e61")
+        private String name;
+        @Schema(type = "string", example = "https://s3.ap-northeast-2.amazonaws.com/sopt-27th/profile/84f6cd04-9985-4da6-94b5-e79fffd88e61")
+        private String profileImageUrl;
+    }
+}

--- a/demo/src/main/java/com/example/demo/member/mapper/CustomerMapper.java
+++ b/demo/src/main/java/com/example/demo/member/mapper/CustomerMapper.java
@@ -2,6 +2,7 @@ package com.example.demo.member.mapper;
 
 import com.example.demo.member.domain.Customer;
 import com.example.demo.member.dto.AuthDTO;
+import com.example.demo.member.dto.MypageDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -13,6 +14,8 @@ public interface CustomerMapper {
     @Mapping(target = "id", ignore = true)
     Customer requestToEntity(AuthDTO.Request memberAuthRequest);
 
-    AuthDTO.Response entityToResponse(Customer customer);
+    AuthDTO.Response entityToAuthDTOResponse(Customer customer);
+
+    MypageDTO.CustomerResponse entityToMypageDTOResponse(Customer customer);
 
 }

--- a/demo/src/main/java/com/example/demo/member/mapper/WeddingPlannerMapper.java
+++ b/demo/src/main/java/com/example/demo/member/mapper/WeddingPlannerMapper.java
@@ -2,6 +2,7 @@ package com.example.demo.member.mapper;
 
 import com.example.demo.member.domain.WeddingPlanner;
 import com.example.demo.member.dto.AuthDTO;
+import com.example.demo.member.dto.MypageDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -15,6 +16,7 @@ public interface WeddingPlannerMapper {
     @Mapping(target = "id", ignore = true)
     WeddingPlanner requestToEntity(AuthDTO.Request weddingPlannerRequest);
 
-    public AuthDTO.Response entityToResponse(WeddingPlanner weddingPlanner);
+    public AuthDTO.Response entityToAuthDTOResponse(WeddingPlanner weddingPlanner);
 
+    public MypageDTO.WeddingPlannerResponse entityToMypageDTOResponse(WeddingPlanner weddingPlanner);
 }

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -6,6 +6,7 @@ import com.example.demo.member.domain.CustomerContext;
 import com.example.demo.member.domain.WeddingPlanner;
 import com.example.demo.member.domain.WeddingPlannerContext;
 import com.example.demo.member.dto.AuthDTO;
+import com.example.demo.member.dto.MypageDTO;
 import com.example.demo.member.mapper.CustomerMapper;
 import com.example.demo.member.mapper.WeddingPlannerMapper;
 import com.example.demo.member.repository.CustomerRepository;
@@ -22,6 +23,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.lang.reflect.Member;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -74,14 +76,14 @@ public class CustomUserDetailsService implements UserDetailsService {
                     .UUID(UUID.randomUUID().toString()).build();
 
             weddingPlannerRepository.save(weddingPlanner);
-            return weddingPlannerMapper.entityToResponse(weddingPlanner);
+            return weddingPlannerMapper.entityToAuthDTOResponse(weddingPlanner);
         } else if (role.equals(MemberRole.CUSTOMER.getRoleName())) {
             Customer customer = Customer.builder()
                     .role(MemberRole.CUSTOMER)
                     .UUID(UUID.randomUUID().toString()).build();
 
             customerRepository.save(customer);
-            return customerMapper.entityToResponse(customer);
+            return customerMapper.entityToAuthDTOResponse(customer);
         } else {
             throw new IllegalArgumentException("잘못된 회원가입 요청입니다.");
         }
@@ -104,5 +106,15 @@ public class CustomUserDetailsService implements UserDetailsService {
             return weddingPlannerRepository.findByUUID(memberName);
         }
         throw new UsernameNotFoundException("인증된 WeddingPlanner를 찾을 수 없습니다.");
+    }
+
+    public MypageDTO.CustomerResponse getCustomerMyPage() {
+        Customer customer = getCurrentAuthenticatedCustomer().orElseThrow();
+        return customerMapper.entityToMypageDTOResponse(customer);
+    }
+
+    public MypageDTO.WeddingPlannerResponse getWeddingPlannerMyPage() {
+        WeddingPlanner weddingPlanner = getCurrentAuthenticatedWeddingPlanner().orElseThrow();
+        return weddingPlannerMapper.entityToMypageDTOResponse(weddingPlanner);
     }
 }

--- a/demo/src/main/java/com/example/demo/review/controller/ReviewCotroller.java
+++ b/demo/src/main/java/com/example/demo/review/controller/ReviewCotroller.java
@@ -58,4 +58,19 @@ public class ReviewCotroller {
         List<ReviewDTO.Response> softDeletedReviews = reviewService.getAllSoftDeletedReviews();
         return ResponseEntity.ok(softDeletedReviews);
     }
+
+    @GetMapping("/customer/myreview")
+    @Operation(summary = "[예비신랑신부용] 내 리뷰 조회")
+    public ResponseEntity<List<ReviewDTO.Response>> getMyReviewsForCustomer() {
+        List<ReviewDTO.Response> myReviews = reviewService.getMyReviewsForCustomer();
+        return ResponseEntity.ok(myReviews);
+    }
+
+    @GetMapping("/weddingplanner/myreview")
+    @Operation(summary = "[웨딩플래너용] 내 리뷰 조회")
+    public ResponseEntity<List<ReviewDTO.Response>> getMyReviewsForWeddingplanner() {
+
+        List<ReviewDTO.Response> myReviews = reviewService.getMyReviewsForWeddingplanner();
+        return ResponseEntity.ok(myReviews);
+    }
 }

--- a/demo/src/main/java/com/example/demo/review/domain/Review.java
+++ b/demo/src/main/java/com/example/demo/review/domain/Review.java
@@ -27,7 +27,7 @@ public class Review extends BaseTimeEntity {
         @Builder.Default
         private boolean isDeleted = Boolean.FALSE;
 
-        private String reviewerName;
+        private Long reviewerId;
         private String content;
         private Boolean isProvided;
 

--- a/demo/src/main/java/com/example/demo/review/repository/ReviewRepository.java
+++ b/demo/src/main/java/com/example/demo/review/repository/ReviewRepository.java
@@ -16,10 +16,16 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Transactional
     @Modifying
-    @Query("UPDATE Review r SET r.isDeleted = true WHERE r.id = :id")
+    @Query(value = "UPDATE Review r SET r.isDeleted = true WHERE r.id = :id")
     void softDeleteById(@Param("id") Long id);
 
-    @Query(value = "SELECT * from Review review WHERE review.is_deleted = true", nativeQuery = true)
+    @Query(value = "SELECT * from Review r WHERE r.is_deleted = true", nativeQuery = true)
     List<Review> findSoftDeletedReviews();
+
+    @Query(value = "SELECT * from Review r WHERE r.is_provided = true and r.reviewer_id = :weddingPlannerId", nativeQuery = true)
+    List<Review> findReviewsForWeddingPlanner(Long weddingPlannerId);
+
+    @Query(value = "SELECT * from Review r WHERE r.is_provided = false and r.reviewer_id = :customerId", nativeQuery = true)
+    List<Review> findReviewsForCustomer(Long customerId);
 
 }

--- a/demo/src/main/java/com/example/demo/review/service/ReviewService.java
+++ b/demo/src/main/java/com/example/demo/review/service/ReviewService.java
@@ -1,6 +1,9 @@
 package com.example.demo.review.service;
 
 import com.example.demo.config.S3Uploader;
+import com.example.demo.member.domain.Customer;
+import com.example.demo.member.domain.WeddingPlanner;
+import com.example.demo.member.service.CustomUserDetailsService;
 import com.example.demo.portfolio.domain.Portfolio;
 import com.example.demo.portfolio.service.PortfolioService;
 import com.example.demo.review.domain.Review;
@@ -8,10 +11,12 @@ import com.example.demo.review.dto.ReviewDTO;
 import com.example.demo.review.mapper.ReviewMapper;
 import com.example.demo.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,6 +28,8 @@ public class ReviewService {
     private final PortfolioService portfolioService;
 
     private final S3Uploader s3Uploader;
+
+    private final CustomUserDetailsService customUserDetailsService;
 
     public List<ReviewDTO.Response> getAllReviews() {
         return reviewRepository.findAll().stream()
@@ -121,5 +128,20 @@ public class ReviewService {
                 .collect(Collectors.toList());
     }
 
+    public List<ReviewDTO.Response> getMyReviewsForCustomer() throws UsernameNotFoundException {
+        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer().orElseThrow();
+        return reviewRepository.findReviewsForCustomer(customer.getId()).stream()
+                .map(reviewMapper::entityToResponse)
+                .collect(Collectors.toList());
+    }
+
+    public List<ReviewDTO.Response> getMyReviewsForWeddingplanner() throws UsernameNotFoundException {
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner().orElseThrow();
+
+        return reviewRepository.findReviewsForWeddingPlanner(weddingPlanner.getId()).stream()
+                        .map(reviewMapper::entityToResponse)
+                        .collect(Collectors.toList());
+
+    }
 
 }


### PR DESCRIPTION
### PR 요약
[관련화면]
<img width="273" alt="image" src="https://github.com/user-attachments/assets/c78418fa-7a50-4994-9d0d-9fe378c929b7">

해당 UI에서 프로필, 닉네임을 가져오는 로직을 추가하였습니다.
추가적으로 "내가 쓴 리뷰" 칸을 위해 Weddingplanner/customer가 각각 호출할 수 있는 API를 구상하였습니다.

### 변경 사항
weddingplanner와 customer가 각각의 마이페이지를 조회할 수 있습니다.

### 참고 사항
