### PR TITLE
feat/search

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -85,6 +85,11 @@ dependencies {
     //TestDB
     testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
 
+    //Aws Opensearch
+    implementation("org.opensearch.client:opensearch-rest-client:2.11.0")
+    implementation("org.opensearch.client:opensearch-java:2.7.0")
+    implementation("jakarta.json:jakarta.json-api")
+
 }
 
 tasks.named('test') {

--- a/demo/src/main/java/com/example/demo/config/OpenSearchConfig.java
+++ b/demo/src/main/java/com/example/demo/config/OpenSearchConfig.java
@@ -1,0 +1,55 @@
+package com.example.demo.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.RestClientBuilder;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenSearchConfig {
+
+    @Value("${spring.elasticsearch.uris}")
+    private String host;
+
+    @Value("${spring.elasticsearch.username}")
+    private String username;
+
+    @Value("${spring.elasticsearch.password}")
+    private String password;
+
+
+    @Bean
+    public OpenSearchClient openSearchClient() {
+        BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(
+                AuthScope.ANY,
+                new UsernamePasswordCredentials(username, password)
+        );
+
+        RestClientBuilder builder = RestClient.builder(new HttpHost(host, 443, "https"))
+                .setHttpClientConfigCallback(new RestClientBuilder.HttpClientConfigCallback(){
+                    @Override
+                    public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
+                        return httpClientBuilder
+                                .setDefaultCredentialsProvider(credentialsProvider)
+                                .setDefaultIOReactorConfig(IOReactorConfig.custom()
+                                        .setIoThreadCount(1)
+                                        .build());
+                    }
+                });
+
+        RestClient restClient = builder.build();
+        return new OpenSearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper(new ObjectMapper())));
+    }
+}

--- a/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
+++ b/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
@@ -1,6 +1,8 @@
 package com.example.demo.portfolio.controller;
 
 import com.example.demo.portfolio.dto.PortfolioDTO;
+import com.example.demo.portfolio.dto.PortfolioSearchDTO;
+import com.example.demo.portfolio.service.PortfolioSearchService;
 import com.example.demo.portfolio.service.PortfolioService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,6 +19,8 @@ import java.util.List;
 public class PortfolioController {
 
     private final PortfolioService portfolioService;
+
+    private final PortfolioSearchService portfolioSearchService;
 
     @GetMapping("")
     @Operation(summary = "전체 포트폴리오 조회")
@@ -58,6 +62,13 @@ public class PortfolioController {
     public ResponseEntity<List<PortfolioDTO.Response>> getAllSoftDeleted() {
         List<PortfolioDTO.Response> softDeletedPortfolios = portfolioService.getAllSoftDeletedPortfolios();
         return ResponseEntity.ok(softDeletedPortfolios);
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "포트폴리오 검색")
+    public ResponseEntity<List<PortfolioSearchDTO.Response>> getSearchPortfolio(@RequestParam String content) {
+        List<PortfolioSearchDTO.Response> searchResult = portfolioSearchService.search(content);
+        return ResponseEntity.ok(searchResult);
     }
 
 }

--- a/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
+++ b/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
@@ -3,6 +3,7 @@ package com.example.demo.portfolio.domain;
 import com.example.demo.base.BaseTimeEntity;
 import com.example.demo.enums.review.RadarKey;
 import com.example.demo.enums.portfolio.Region;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Where;
@@ -16,6 +17,7 @@ import java.util.Map;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@JsonIgnoreProperties (ignoreUnknown=true)
 @Where(clause = "is_deleted = false")
 public class Portfolio extends BaseTimeEntity {
 
@@ -37,12 +39,12 @@ public class Portfolio extends BaseTimeEntity {
     private Integer consultingFee;
     private String description;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "portfolio_services", joinColumns = @JoinColumn(name = "portfolio_id"))
     @Column(name = "service_value")
     private List<String> services;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "portfolio_wedding_photos", joinColumns = @JoinColumn(name = "portfolio_id"))
     @Column(name = "photo_url")
     private List<String> weddingPhotoUrls;
@@ -55,7 +57,7 @@ public class Portfolio extends BaseTimeEntity {
     private Integer estimateCount;
     private Integer minEstimate;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "portfolio_radar", joinColumns = @JoinColumn(name = "portfolio_id"))
     @MapKeyColumn(name = "radar_key")
     @Column(name = "radar_value")

--- a/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioDTO.java
+++ b/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioDTO.java
@@ -18,6 +18,9 @@ public class PortfolioDTO {
     @Builder
     public static class Request {
 
+        @Schema(type = "Long", example = "1")
+        private Long id;
+
         @Schema(type = "string", example = "에바웨딩스")
         private String organization;
 
@@ -69,11 +72,6 @@ public class PortfolioDTO {
         @Schema(type = "integer", example = "62")
         private Integer radarCount;
 
-        @Schema(type = "LocalDateTime", example = "2024-07-04 16:53:33.130731")
-        private LocalDateTime createdAt;
-
-        @Schema(type = "LocalDateTime", example = "2024-07-04 16:53:33.130731")
-        private LocalDateTime updatedAt;
     }
 
     @Setter
@@ -83,6 +81,10 @@ public class PortfolioDTO {
     @AllArgsConstructor
     @Builder
     public static class Response {
+
+        @Schema(type = "Long", example = "1")
+        private Long id;
+
         @Schema(type = "string", example = "에바웨딩스")
         private String organization;
 

--- a/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioSearchDTO.java
+++ b/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioSearchDTO.java
@@ -1,0 +1,95 @@
+package com.example.demo.portfolio.dto;
+
+import com.example.demo.enums.review.RadarKey;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+public class PortfolioSearchDTO {
+
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+
+        @Schema(type = "Long", example = "1")
+        private Long id;
+
+        @Schema(type = "string", example = "에바웨딩스")
+        private String organization;
+
+        @Schema(type = "string", example = "김지수")
+        private String plannerName;
+
+        @Schema(type = "string", example = "GANGNAM")
+        private String region;
+
+        @Schema(type = "string", example = "안녕하세요.")
+        private String introduction;
+
+        @Schema(type = "integer", example = "30000")
+        private Integer consultingFee;
+
+        @Schema(type = "string", example = "웨딩 준비 도와드릴게요.")
+        private String description;
+
+        @Schema(type = "float", example = "3.723123")
+        private Float ratingSum;
+
+        @Schema(type = "integer", example = "42")
+        private Integer ratingCount;
+
+        @Schema(type = "integer", example = "40000")
+        private Integer avgEstimate;
+
+        @Schema(type = "integer", example = "62")
+        private Integer estimateSum;
+
+        @Schema(type = "integer", example = "20000")
+        private Integer minEstimate;
+
+        @Schema(type = "array", example = "[\"퍼스널 컬러 체크\", \"웨딩드레스 시착 1회 무료\"]")
+        private List<String> services;
+
+        @Schema(type = "object", example = "{\"COMMUNICATION\": 4.5, \"BUDGET_COMPLIANCE\": 3.8, \"PERSONAL_CUSTOMIZATION\": 4.7, \"PRICE_NATIONALITY\": 4.0, \"SCHEDULE_COMPLIANCE\": 4.6}")
+        private Map<RadarKey, Float> avgRadar;
+
+        @Schema(type = "integer", example = "62")
+        private Integer radarCount;
+
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        @Schema(type = "Long", example = "1")
+        private Long id;
+
+        @Schema(type = "string", example = "에바웨딩스")
+        private String organization;
+
+        @Schema(type = "string", example = "김지수")
+        private String plannerName;
+
+        @Schema(type = "float", example = "3.723123")
+        private Float ratingSum;
+
+        @Schema(type = "integer", example = "42")
+        private Integer ratingCount;
+
+        @Schema(type = "integer", example = "20000")
+        private Integer minEstimate;
+
+    }
+
+}

--- a/demo/src/main/java/com/example/demo/portfolio/mapper/PortfolioMapper.java
+++ b/demo/src/main/java/com/example/demo/portfolio/mapper/PortfolioMapper.java
@@ -3,6 +3,7 @@ package com.example.demo.portfolio.mapper;
 import com.example.demo.portfolio.domain.Portfolio;
 import com.example.demo.portfolio.dto.PortfolioDTO;
 import com.example.demo.portfolio.dto.PortfolioOverviewDTO;
+import com.example.demo.portfolio.dto.PortfolioSearchDTO;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -24,4 +25,8 @@ public interface PortfolioMapper {
     Portfolio updateFromRequest(PortfolioDTO.Request portfolioRequest, @MappingTarget Portfolio portfolio);
 
     PortfolioOverviewDTO.Response entityToOverviewResponse(Portfolio portfolio);
+
+    PortfolioSearchDTO.Request entityToSearchRequest(Portfolio portfolio);
+
+    PortfolioSearchDTO.Response requestToSearchResponse(PortfolioSearchDTO.Request request);
 }

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioSearchService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioSearchService.java
@@ -1,0 +1,134 @@
+package com.example.demo.portfolio.service;
+
+import com.example.demo.portfolio.domain.Portfolio;
+import com.example.demo.portfolio.dto.PortfolioSearchDTO;
+import com.example.demo.portfolio.mapper.PortfolioMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.*;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class PortfolioSearchService {
+
+    private final OpenSearchClient openSearchClient;
+    private static final String indexName = "portfolio";
+    private final PortfolioMapper portfolioMapper;
+
+    public PortfolioSearchService(OpenSearchClient openSearchClient, PortfolioMapper portfolioMapper) {
+        this.openSearchClient = openSearchClient;
+        this.portfolioMapper = portfolioMapper;
+    }
+
+    //인덱스 생성
+    public void createIndex() {
+        try {
+            CreateIndexRequest request = CreateIndexRequest.of(builder -> builder.index(indexName));
+            openSearchClient.indices().create(request);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void indexDocumentUsingDTO(Portfolio portfolio) {
+
+        PortfolioSearchDTO.Request request = portfolioMapper.entityToSearchRequest(portfolio);
+        try {
+            IndexRequest<PortfolioSearchDTO.Request> indexRequest = IndexRequest.of(builder ->
+                    builder.index(indexName)
+                            .id(String.valueOf(request.getId()))
+                            .document(request)
+            );
+            IndexResponse response = openSearchClient.index(indexRequest);
+            System.out.println("RESPONSE: "+response);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void updateDocumentUsingDTO(Portfolio portfolio){
+
+        PortfolioSearchDTO.Request request = portfolioMapper.entityToSearchRequest(portfolio);
+
+        try {
+            UpdateRequest<PortfolioSearchDTO.Request, Object> updateRequest = UpdateRequest.of(builder ->
+                    builder.index(indexName)
+                            .id(String.valueOf(portfolio.getId()))
+                            .doc(request)
+            );
+
+            UpdateResponse updateResponse = openSearchClient.update(updateRequest, PortfolioSearchDTO.Request.class);
+            System.out.println("Update Response: " + updateResponse.get());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public List<PortfolioSearchDTO.Response> search(String keyword) {
+        List<PortfolioSearchDTO.Response> resultList = new ArrayList<>();
+
+        try {
+            SearchRequest request = SearchRequest.of(searchRequest ->
+                searchRequest.index(indexName)
+                    .query(query ->
+                        query.bool(bool ->
+                            bool.should(should ->
+                                should.wildcard(wildcard ->
+                                    wildcard.field("services")
+                                        .value("*" + keyword + "*")
+                                )
+                            )
+                            .should(should ->
+                                should.wildcard(wildcard ->
+                                    wildcard.field("plannerName")
+                                    .value("*" + keyword + "*")
+                                )
+                            )
+                            .should(should ->
+                                should.wildcard(wildcard ->
+                                    wildcard.field("organization")
+                                    .value("*" + keyword + "*")
+                                )
+                            )
+                            .should(should ->
+                                should.wildcard(wildcard ->
+                                    wildcard.field("introduction")
+                                        .value("*" + keyword + "*")
+                                )
+                            )
+                        )
+                    )
+            );
+
+            SearchResponse<PortfolioSearchDTO.Request> response = openSearchClient.search(request, PortfolioSearchDTO.Request.class);
+            List<Hit<PortfolioSearchDTO.Request>> hits = response.hits().hits();
+            System.out.println("HITS: "+hits);
+            for (Hit<PortfolioSearchDTO.Request> hit : hits) {
+                resultList.add(portfolioMapper.requestToSearchResponse(hit.source()));
+            }
+
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return resultList;
+    }
+
+    public void deleteDocumentById(Long id) {
+        try {
+            DeleteRequest deleteRequest = DeleteRequest.of(builder ->
+                    builder.index(indexName)
+                            .id(String.valueOf(id))
+            );
+            DeleteResponse response = openSearchClient.delete(deleteRequest);
+            System.out.println("Delete Response: " + response);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}
+

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -25,6 +25,8 @@ public class PortfolioService {
 
     private final S3Uploader s3Uploader;
 
+    private final PortfolioSearchService portfolioSearchService;
+
     public List<PortfolioDTO.Response> getAllPortfolios() {
         return portfolioRepository.findAll().stream()
                 .map(portfolioMapper::entityToResponse)
@@ -61,7 +63,7 @@ public class PortfolioService {
         response.setWeddingPhotoUrls(portfolio.getWeddingPhotoUrls().stream()
                 .map(s3Uploader::getImageUrl)
                 .collect(Collectors.toList()));
-
+        portfolioSearchService.indexDocumentUsingDTO(portfolio);
         return response;
     }
 
@@ -95,7 +97,7 @@ public class PortfolioService {
         response.setWeddingPhotoUrls(updatedPortfolio.getWeddingPhotoUrls().stream()
                 .map(s3Uploader::getImageUrl)
                 .collect(Collectors.toList()));
-
+        portfolioSearchService.updateDocumentUsingDTO(savedPortfolio);
         return portfolioMapper.entityToResponse(savedPortfolio);
     }
 
@@ -115,6 +117,7 @@ public class PortfolioService {
         }
 
         portfolioRepository.softDeleteById(id);
+        portfolioSearchService.deleteDocumentById(id); //검색으로는 나타나지 못하도록 구현
     }
 
     public List<PortfolioDTO.Response> getAllSoftDeletedPortfolios() {
@@ -130,6 +133,7 @@ public class PortfolioService {
 
         portfolio.increaseWishListCount();
         portfolioRepository.save(portfolio);
+        portfolioSearchService.updateDocumentUsingDTO(portfolio);
         return portfolio;
     }
 
@@ -140,6 +144,7 @@ public class PortfolioService {
 
         portfolio.decreaseWishListCount();
         portfolioRepository.save(portfolio);
+        portfolioSearchService.updateDocumentUsingDTO(portfolio);
         return portfolio;
     }
 
@@ -163,6 +168,7 @@ public class PortfolioService {
         portfolio.increaseRadarCount(radar);
 
         portfolioRepository.save(portfolio);
+        portfolioSearchService.updateDocumentUsingDTO(portfolio);
 
         return portfolio;
     }
@@ -192,6 +198,8 @@ public class PortfolioService {
         portfolio.accumulateRadarSum(newRadar);
 
         portfolioRepository.save(portfolio);
+        portfolioSearchService.updateDocumentUsingDTO(portfolio);
+
 
         return portfolio;
 

--- a/demo/src/main/resources/application.yml
+++ b/demo/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8080
+
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -23,30 +26,12 @@ spring:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
-
-  security:
-    oauth2:
-      client:
-        registration:
-          kakao:
-            client-id: 772ee8988ee944d126d126ee9b3ccab2
-            client-secret: mVi0XG4Zi8lry3d76hx76oxlJnvzHA1x
-            scope:
-              - profile_nickname
-            authorization-grant-type: authorization_code
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
-            client-name: Kakao
-            client-authentication-method: client_secret_post
-
-        provider:
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-name-attribute: id
-
-server:
-  port: 8080
+  elasticsearch:
+    uris: ${ELASTICSEARCH_URL}
+    username: ${ELASTICSEARCH_USERNAME}
+    password: ${ELASTICSEARCH_PASSWORD}
+    repositories:
+      enabled: true
 
 springdoc:
   api-docs:
@@ -57,9 +42,3 @@ springdoc:
     operations-sorter: alpha
     display-request-duration: true
   use-fqn: true
-
-jwt:
-  header: Authorization
-  #HS512 ????? ??? ??? ??? 512bit, ? 64byte ??? secret key? ???? ??.
-  secret: a2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbXRva2FyaW10b2thcmltdG9rYXJpbQ==
-  token-validity-in-seconds: 86400 # ttl (?)

--- a/demo/src/test/java/com/example/demo/portfolio/PortfolioSearchTest.java
+++ b/demo/src/test/java/com/example/demo/portfolio/PortfolioSearchTest.java
@@ -1,0 +1,83 @@
+package com.example.demo.portfolio;
+
+import com.example.demo.config.S3Config;
+import com.example.demo.config.S3Uploader;
+import com.example.demo.portfolio.domain.Portfolio;
+import com.example.demo.portfolio.dto.PortfolioSearchDTO;
+import com.example.demo.portfolio.repository.PortfolioRepository;
+import com.example.demo.portfolio.service.PortfolioSearchService;
+import com.example.demo.portfolio.service.PortfolioService;
+import com.example.demo.review.dto.ReviewDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class PortfolioSearchTest {
+
+    @MockBean
+    private S3Uploader s3Uploader;
+
+    @MockBean
+    private S3Config s3Config;
+
+
+    @Autowired
+    private PortfolioRepository portfolioRepository;
+
+    @Autowired
+    private PortfolioSearchService portfolioSearchService;
+
+    @Autowired
+    private PortfolioService portfolioService;
+
+
+    @Test
+    public void 포트폴리오_입력() {
+        Portfolio portfolio1 = portfolioRepository.findById(1L).orElseThrow();
+        portfolioSearchService.indexDocumentUsingDTO(portfolio1);
+
+        Portfolio portfolio2 = portfolioRepository.findById(2L).orElseThrow();
+        portfolioSearchService.indexDocumentUsingDTO(portfolio2);
+
+    }
+
+    @Test
+    public void 포트폴리오_검색() {
+        List<PortfolioSearchDTO.Response> searchResult = portfolioSearchService.search("f");
+        System.out.println("SEARCH: "+searchResult);
+
+    }
+
+    @Test
+    public void 포트폴리오_수정() {
+        Portfolio portfolio = portfolioRepository.findById(1L).orElseThrow();
+        portfolio.setOrganization("에바웨딩스");
+        portfolioSearchService.updateDocumentUsingDTO(portfolio);
+    }
+
+    @Test
+    public void 포트폴리오_삭제() {
+        Portfolio portfolio = portfolioRepository.findById(1L).orElseThrow();
+        portfolioSearchService.deleteDocumentById(portfolio.getId());
+    }
+
+    @Test
+    public void 포트폴리오_리뷰_추가() {
+        Portfolio portfolio = portfolioRepository.findById(1L).orElseThrow();
+        ReviewDTO.Request reviewReq = ReviewDTO.Request.builder()
+                .reviewerName("김민영")
+                .portfolioId(1L)
+                .isProvided(false)
+                .content("잘해줍니다.")
+                .estimate(10)
+                .build();
+
+        portfolioService.reflectNewReview(reviewReq);
+    }
+}


### PR DESCRIPTION
### PR 요약
AWS OpenSearch를 활용하여 Portfolio를 인덱싱 및 검색하는 로직 추가

### 변경 사항
기존에 있던 필드의 변경사항을 정리하였습니다.

Portfolio Entity 변경사항
- @JsonIgnoreProperties 추가 : OpenSearch에 인덱싱하는 과정에서 Json 파싱 시 없는 필드를 무시하기 위해 필요합니다.
- ElementCollection(fetch = FetchType.EAGER) : OpenSearch에 인덱싱하는 과정에서 지연로딩이 발생할 시 services, radar 관련 필드를 불러오는 것에 한계가 있어 EAGER 조건으로 수정하였습니다.

PortfolioDTO 변경사항
- createdAt, updatedAt의 경우 DTO에 있는 것은 적합하지 않다고 판단하여 삭제하였습니다.

YML 파일 변경사항
YML 파일의 Jwt, OAuth2 설정의 경우 구현계획이 멀기 때문에 혼동 방지를 위해 우선 삭제해 두었습니다. (이후 추가 예정)

### 참고 사항
[BACK]
1. IntelliJ에서 환경변수를 세팅해주어야 합니다. notion 환경변수 칸에 정리해두었습니다.
2. 함께 고민해볼 문제가 있습니다!

>**elasticsearch 에서 isdeleted 된 것 처리**
>1. 일단 검색창에서는 보이고 들어가면 ‘삭제된 글입니다.’
>2. 검색 아예 안되도록 구현 ☑

>**동기화 문제 → 반환되는 필드 값 계속 갱신해줘야 ??**
>1. 아래 필드에서 바뀌는 사항이 한 개라도 존재하면 opensearch에도 적용해주기 ☑
>2. 하루에 한 번 배치 돌기
>3. 글자에 해당하는 것만 검색 가능하도록 하고, 자세한 내용은 getPortfolioById(2) 로 다시 가져오기

[FRONT]
1. Swagger에 검색 관련 API를 추가하였습니다.
2. 추후 검색 기능이 더 커스텀화되면 공유해주세요 ! (ex. radar chart 나 비용 등 숫자 기반 컬럼의 범위 검색 기능, 웨딩플래너 명 만 선택하여 검색하는 태그 기반 기능)
