### PR TITLE
Refact/qa controller exception handling

### DIFF
--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -30,7 +30,7 @@ public class ChatRoomService {
     private final PortfolioService portfolioService;
 
     public ChatRoomDTO.Response enterChatRoomByPortfolioId(Long portfolioId) {
-        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer().get();
+        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
         PortfolioDTO.Response portfolioResponse = portfolioService.getPortfolioById(portfolioId);
 
         WeddingPlanner weddingPlanner = portfolioResponse.getWeddingPlanner();
@@ -72,7 +72,7 @@ public class ChatRoomService {
     }
 
     public List<ChatRoomOverviewDTO.Response> getCurrentUsersAllChatRoom() {
-        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer().get();
+        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
         List<ChatRoom> chatRooms = chatRoomRepository.findByCustomerId(customer.getId());
 
         return chatRooms.stream()

--- a/demo/src/main/java/com/example/demo/config/S3Uploader.java
+++ b/demo/src/main/java/com/example/demo/config/S3Uploader.java
@@ -39,7 +39,7 @@ public class S3Uploader {
 
     // Upload file to S3 using presigned url
     private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String fileName) {
-        return new GeneratePresignedUrlRequest(bucket, "test/" + fileName)
+        return new GeneratePresignedUrlRequest(bucket, cloudfrontPath + "/" + fileName)
                 .withMethod(HttpMethod.PUT)
                 .withExpiration(setExpiration());
     }
@@ -71,8 +71,9 @@ public class S3Uploader {
         if (fileName == null) {
             return;
         }
-        s3Config.amazonS3().deleteObject(new DeleteObjectRequest(bucket, "test/"+fileName));
-        System.out.println(fileName);
+        if (checkFileExists(fileName)){
+            s3Config.amazonS3().deleteObject(new DeleteObjectRequest(bucket, cloudfrontPath+"/"+fileName));
+        }
     }
 
     public void deleteFiles(List<String> fileNames) {
@@ -105,5 +106,9 @@ public class S3Uploader {
         return imageUrls.stream()
                 .map(this::getImageUrl)
                 .collect(Collectors.toList());
+    }
+
+    public boolean checkFileExists(String fileName) {
+        return s3Config.amazonS3().doesObjectExist(bucket, cloudfrontPath + "/" + fileName);
     }
 }

--- a/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
+++ b/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -123,6 +124,13 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
         log.error("handleNullPointerException", e);
         final ErrorResponse response = ErrorResponse.of(ErrorCode.NULL_POINT_ERROR, e.getMessage());
+        return new ResponseEntity<>(response, HTTP_STATUS_OK);
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleUsernameNotFoundException(UsernameNotFoundException e) {
+        log.error("handleUsernameNotFoundException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.FORBIDDEN_ERROR, e.getMessage());
         return new ResponseEntity<>(response, HTTP_STATUS_OK);
     }
 

--- a/demo/src/main/java/com/example/demo/member/controller/MemberController.java
+++ b/demo/src/main/java/com/example/demo/member/controller/MemberController.java
@@ -11,28 +11,28 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/member")
+@RequestMapping("/api/v1")
 @Tag(name = "member", description = "멤버 API")
 public class MemberController {
 
     private final CustomUserDetailsService customUserDetailsService;
 
-    @PostMapping("/token")
-    @Operation(summary = "토큰이 없을 때 유저 생성", description = "CUSTOMER 또는 WEDDINGPLANNER로 권한을 요청합니다.")
+    @PostMapping("/auth/create")
+    @Operation(summary = "[공통] 토큰이 없을 때 유저 생성", description = "CUSTOMER 또는 WEDDINGPLANNER로 권한을 요청합니다.")
     public ResponseEntity<AuthDTO.Response> createMember(@RequestBody AuthDTO.Request customerAuthRequest){
         AuthDTO.Response createdMember = customUserDetailsService.join(customerAuthRequest.getRole());
         return ResponseEntity.status(201).body(createdMember);
     }
 
-    @GetMapping("/customer/mypage")
-    @Operation(summary = "유저 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")
+    @GetMapping("/customer/mypage/get")
+    @Operation(summary = "[신랑신부] 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")
     public ResponseEntity<MypageDTO.CustomerResponse> getCustomerMyPage(){
         MypageDTO.CustomerResponse myPage = customUserDetailsService.getCustomerMyPage();
         return ResponseEntity.status(200).body(myPage);
     }
 
-    @GetMapping("/weddingplanner/mypage")
-    @Operation(summary = "웨딩플래너 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")
+    @GetMapping("/weddingplanner/mypage/get")
+    @Operation(summary = "[웨딩플래너] 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")
     public ResponseEntity<MypageDTO.WeddingPlannerResponse> getWeddingPlannerMyPage(){
         MypageDTO.WeddingPlannerResponse myPage = customUserDetailsService.getWeddingPlannerMyPage();
         return ResponseEntity.status(200).body(myPage);

--- a/demo/src/main/java/com/example/demo/member/controller/MemberController.java
+++ b/demo/src/main/java/com/example/demo/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -24,6 +25,7 @@ public class MemberController {
         return ResponseEntity.status(201).body(createdMember);
     }
 
+    @ExceptionHandler(MissingRequestHeaderException.class)
     @GetMapping("/customer/mypage/get")
     @Operation(summary = "[신랑신부] 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")
     public ResponseEntity<MypageDTO.CustomerResponse> getCustomerMyPage(){

--- a/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
+++ b/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
@@ -39,7 +39,7 @@ public class WeddingPlanner {
     private String profileImageUrl;
 
     //포트폴리오 1:1
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "weddingplanner_id")
     private Portfolio portfolio;
 

--- a/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
+++ b/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
@@ -5,6 +5,7 @@ import com.example.demo.portfolio.dto.PortfolioSearchDTO;
 import com.example.demo.portfolio.service.PortfolioSearchService;
 import com.example.demo.portfolio.service.PortfolioService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/portfolio")
+@RequestMapping("/api/v1")
 @Tag(name = "portfolio", description = "포트폴리오 API")
 public class PortfolioController {
 
@@ -22,51 +23,59 @@ public class PortfolioController {
 
     private final PortfolioSearchService portfolioSearchService;
 
-    @GetMapping("")
-    @Operation(summary = "전체 포트@폴리오 조회")
-    public ResponseEntity<List<PortfolioDTO.Response>> getAllPortfolios() {
-        List<PortfolioDTO.Response> portfolioResponses = portfolioService.getAllPortfolios();
-        return ResponseEntity.ok(portfolioResponses);
-    }
-
-    @GetMapping("/{id}")
-    @Operation(summary = "특정 포트폴리오 조회")
-    public ResponseEntity<PortfolioDTO.Response> getPortfolioById(@PathVariable Long id) {
+    @GetMapping("/portfolio/get/{id}")
+    @Operation(summary = "[공통] 특정 포트폴리오 조회")
+    public ResponseEntity<PortfolioDTO.Response> getPortfolioById(
+            @Parameter(description = "portfolioId")
+            @PathVariable Long id) {
         PortfolioDTO.Response portfolioResponse = portfolioService.getPortfolioById(id);
         return ResponseEntity.ok(portfolioResponse);
     }
 
-    @PostMapping("")
-    @Operation(summary = "포트폴리오 작성")
+    @PostMapping("/weddingplanner/portfolio/create")
+    @Operation(summary = "[웨딩플래너] 포트폴리오 작성")
     public ResponseEntity<PortfolioDTO.Response> createPortfolio(@RequestBody PortfolioDTO.Request portfolioRequest) {
         PortfolioDTO.Response createdPortfolio = portfolioService.createPortfolio(portfolioRequest);
         return ResponseEntity.status(201).body(createdPortfolio);
     }
 
-    @PostMapping("/update/{id}")
-    @Operation(summary = "특정 포트폴리오 업데이트")
-    public ResponseEntity<PortfolioDTO.Response> updatePortfolio(@PathVariable Long id, @RequestBody PortfolioDTO.Request portfolioRequest) {
+    @PostMapping("/weddingplanner/portfolio/update/{id}")
+    @Operation(summary = "[웨딩플래너] 특정 포트폴리오 업데이트")
+    public ResponseEntity<PortfolioDTO.Response> updatePortfolio(
+            @Parameter(description = "portfolioId")
+            @PathVariable Long id, @RequestBody PortfolioDTO.Request portfolioRequest) {
         PortfolioDTO.Response updatedPortfolio = portfolioService.updatePortfolio(id, portfolioRequest);
         return ResponseEntity.ok(updatedPortfolio);
     }
 
-    @PostMapping("/delete/{id}")
-    @Operation(summary = "특정 포트폴리오 삭제")
-    public ResponseEntity<Void> deletePortfolio(@PathVariable Long id) {
+    @PostMapping("/weddingplanner/portfolio/delete/{id}")
+    @Operation(summary = "[웨딩플래너] 특정 포트폴리오 삭제")
+    public ResponseEntity<Void> deletePortfolio(
+            @Parameter(description = "portfolioId")
+            @PathVariable Long id) {
         portfolioService.deletePortfolio(id);
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/soft-deleted")
-    @Operation(summary = "soft-deleted 포트폴리오 조회")
+    @GetMapping("/portfolio/get/soft-deleted")
+    @Operation(summary = "[공통] soft-deleted가 된 포트폴리오 조회")
     public ResponseEntity<List<PortfolioDTO.Response>> getAllSoftDeleted() {
         List<PortfolioDTO.Response> softDeletedPortfolios = portfolioService.getAllSoftDeletedPortfolios();
         return ResponseEntity.ok(softDeletedPortfolios);
     }
 
-    @GetMapping("/search")
-    @Operation(summary = "포트폴리오 검색")
-    public ResponseEntity<List<PortfolioSearchDTO.Response>> getSearchPortfolio(@RequestParam String content) {
+    @GetMapping("/portfolio/get")
+    @Operation(summary = "[공통] soft-deleted 를 포함한 전체 포트폴리오 조회")
+    public ResponseEntity<List<PortfolioDTO.Response>> getAllPortfolios() {
+        List<PortfolioDTO.Response> portfolioResponses = portfolioService.getAllPortfolios();
+        return ResponseEntity.ok(portfolioResponses);
+    }
+
+    @GetMapping("/portfolio/search")
+    @Operation(summary = "[공통] 포트폴리오 검색하여 조회")
+    public ResponseEntity<List<PortfolioSearchDTO.Response>> getSearchPortfolio(
+            @Parameter(description = "검색 키워드")
+            @RequestParam String content) {
         List<PortfolioSearchDTO.Response> searchResult = portfolioSearchService.search(content);
         return ResponseEntity.ok(searchResult);
     }

--- a/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
+++ b/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
@@ -40,15 +40,15 @@ public class Portfolio extends BaseTimeEntity {
     private Integer consultingFee;
     private String description;
 
-    @OneToOne(fetch = FetchType.EAGER, mappedBy = "portfolio")
+    @OneToOne
     private WeddingPlanner weddingPlanner;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "portfolio_services", joinColumns = @JoinColumn(name = "portfolio_id"))
     @Column(name = "service_value")
     private List<String> services;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "portfolio_wedding_photos", joinColumns = @JoinColumn(name = "portfolio_id"))
     @Column(name = "photo_url")
     private List<String> weddingPhotoUrls;
@@ -61,7 +61,7 @@ public class Portfolio extends BaseTimeEntity {
     private Integer estimateCount;
     private Integer minEstimate;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "portfolio_radar", joinColumns = @JoinColumn(name = "portfolio_id"))
     @MapKeyColumn(name = "radar_key")
     @Column(name = "radar_value")

--- a/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioDTO.java
+++ b/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioDTO.java
@@ -19,9 +19,6 @@ public class PortfolioDTO {
     @Builder
     public static class Request {
 
-        @Schema(type = "Long", example = "1")
-        private Long id;
-
         @Schema(type = "string", example = "에바웨딩스")
         private String organization;
 

--- a/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioReviewDTO.java
+++ b/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioReviewDTO.java
@@ -46,6 +46,9 @@ public class PortfolioReviewDTO {
     @Builder
     public static class Response {
 
+        @Schema(type = "Long", example = "1")
+        private Long id;
+
         @Schema(type = "float", example = "3.723123")
         private Float avgRating;
 

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioSearchService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioSearchService.java
@@ -44,7 +44,6 @@ public class PortfolioSearchService {
                             .document(request)
             );
             IndexResponse response = openSearchClient.index(indexRequest);
-            System.out.println("RESPONSE: "+response);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -62,7 +61,6 @@ public class PortfolioSearchService {
             );
 
             UpdateResponse updateResponse = openSearchClient.update(updateRequest, PortfolioSearchDTO.Request.class);
-            System.out.println("Update Response: " + updateResponse.get());
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -106,7 +104,6 @@ public class PortfolioSearchService {
 
             SearchResponse<PortfolioSearchDTO.Request> response = openSearchClient.search(request, PortfolioSearchDTO.Request.class);
             List<Hit<PortfolioSearchDTO.Request>> hits = response.hits().hits();
-            System.out.println("HITS: "+hits);
             for (Hit<PortfolioSearchDTO.Request> hit : hits) {
                 resultList.add(portfolioMapper.requestToSearchResponse(hit.source()));
             }
@@ -125,7 +122,6 @@ public class PortfolioSearchService {
                             .id(String.valueOf(id))
             );
             DeleteResponse response = openSearchClient.delete(deleteRequest);
-            System.out.println("Delete Response: " + response);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -11,6 +11,7 @@ import com.example.demo.portfolio.dto.PortfolioDTO;
 import com.example.demo.review.domain.Review;
 import com.example.demo.review.dto.ReviewDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,8 +49,7 @@ public class PortfolioService {
     @Transactional
     public PortfolioDTO.Response createPortfolio(PortfolioDTO.Request portfolioRequest) {
 
-        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner()
-                .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
 
         //Change image name to be unique
         portfolioRequest.setProfileImageUrl(s3Uploader.getUniqueFilename(portfolioRequest.getProfileImageUrl()));
@@ -80,8 +80,7 @@ public class PortfolioService {
     @Transactional
     public PortfolioDTO.Response updatePortfolio(Long id, PortfolioDTO.Request portfolioRequest) {
 
-        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner()
-                .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
 
         Portfolio existingPortfolio = portfolioRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Portfolio not found"));
@@ -119,8 +118,7 @@ public class PortfolioService {
     @Transactional
     public void deletePortfolio(Long id) {
 
-        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner()
-                .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
 
         Portfolio portfolio = portfolioRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Portfolio not found"));

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -2,6 +2,8 @@ package com.example.demo.portfolio.service;
 
 import com.example.demo.config.S3Uploader;
 import com.example.demo.enums.review.RadarKey;
+import com.example.demo.member.domain.WeddingPlanner;
+import com.example.demo.member.service.CustomUserDetailsService;
 import com.example.demo.portfolio.mapper.PortfolioMapper;
 import com.example.demo.portfolio.repository.PortfolioRepository;
 import com.example.demo.portfolio.domain.Portfolio;
@@ -27,6 +29,8 @@ public class PortfolioService {
 
     private final PortfolioSearchService portfolioSearchService;
 
+    private final CustomUserDetailsService customUserDetailsService;
+
     public List<PortfolioDTO.Response> getAllPortfolios() {
         return portfolioRepository.findAll().stream()
                 .map(portfolioMapper::entityToResponse)
@@ -43,6 +47,10 @@ public class PortfolioService {
 
     @Transactional
     public PortfolioDTO.Response createPortfolio(PortfolioDTO.Request portfolioRequest) {
+
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner()
+                .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
+
         //Change image name to be unique
         portfolioRequest.setProfileImageUrl(s3Uploader.getUniqueFilename(portfolioRequest.getProfileImageUrl()));
         portfolioRequest.setWeddingPhotoUrls(portfolioRequest.getWeddingPhotoUrls().stream()
@@ -53,22 +61,28 @@ public class PortfolioService {
         String presignedUrl = s3Uploader.uploadFile(portfolioRequest.getProfileImageUrl());
         List<String> presignedUrlList = s3Uploader.uploadFileList(portfolioRequest.getWeddingPhotoUrls());
         //save portfolio, set presigned url and cloudfront url to response
-        Portfolio portfolio = portfolioMapper.requestToEntity(portfolioRequest);
-        portfolio = portfolioRepository.save(portfolio);
-        PortfolioDTO.Response response = portfolioMapper.entityToResponse(portfolio);
+        Portfolio savedPortfolio = portfolioMapper.requestToEntity(portfolioRequest);
+        savedPortfolio = portfolioRepository.save(savedPortfolio);
+        weddingPlanner.setPortfolio(savedPortfolio);
+
+        PortfolioDTO.Response response = portfolioMapper.entityToResponse(savedPortfolio);
         response.setPresignedProfileImageUrl(presignedUrl);
         response.setPresignedWeddingPhotoUrls(presignedUrlList);
 
-        response.setProfileImageUrl(s3Uploader.getImageUrl(portfolio.getProfileImageUrl()));
-        response.setWeddingPhotoUrls(portfolio.getWeddingPhotoUrls().stream()
+        response.setProfileImageUrl(s3Uploader.getImageUrl(savedPortfolio.getProfileImageUrl()));
+        response.setWeddingPhotoUrls(savedPortfolio.getWeddingPhotoUrls().stream()
                 .map(s3Uploader::getImageUrl)
                 .collect(Collectors.toList()));
-        portfolioSearchService.indexDocumentUsingDTO(portfolio);
+        portfolioSearchService.indexDocumentUsingDTO(savedPortfolio);
         return response;
     }
 
     @Transactional
     public PortfolioDTO.Response updatePortfolio(Long id, PortfolioDTO.Request portfolioRequest) {
+
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner()
+                .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
+
         Portfolio existingPortfolio = portfolioRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Portfolio not found"));
         if(portfolioRequest.getProfileImageUrl() != null) {
@@ -89,6 +103,7 @@ public class PortfolioService {
         Portfolio updatedPortfolio = portfolioMapper.updateFromRequest(portfolioRequest, existingPortfolio);
 
         Portfolio savedPortfolio = portfolioRepository.save(updatedPortfolio);
+        weddingPlanner.setPortfolio(savedPortfolio);
         PortfolioDTO.Response response = portfolioMapper.entityToResponse(savedPortfolio);
         response.setPresignedProfileImageUrl(updatedPortfolio.getProfileImageUrl());
         response.setPresignedWeddingPhotoUrls(updatedPortfolio.getWeddingPhotoUrls());
@@ -103,6 +118,10 @@ public class PortfolioService {
 
     @Transactional
     public void deletePortfolio(Long id) {
+
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner()
+                .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
+
         Portfolio portfolio = portfolioRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Portfolio not found"));
 
@@ -115,6 +134,8 @@ public class PortfolioService {
         if (weddingPhotoUrls != null) {
             weddingPhotoUrls.forEach(s3Uploader::deleteFile);
         }
+
+        weddingPlanner.setPortfolio(null);
 
         portfolioRepository.softDeleteById(id);
         portfolioSearchService.deleteDocumentById(id); //검색으로는 나타나지 못하도록 구현

--- a/demo/src/main/java/com/example/demo/review/controller/ReviewCotroller.java
+++ b/demo/src/main/java/com/example/demo/review/controller/ReviewCotroller.java
@@ -3,6 +3,7 @@ package com.example.demo.review.controller;
 import com.example.demo.review.dto.ReviewDTO;
 import com.example.demo.review.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,62 +13,93 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/review")
+@RequestMapping("/api/v1")
 @Tag(name = "review", description = "리뷰 API")
 public class ReviewCotroller {
 
     private final ReviewService reviewService;
 
-    @GetMapping("")
-    @Operation(summary = "전체 리뷰 조회")
+    @GetMapping("/review/get")
+    @Operation(summary = "[공통] 전체 리뷰 조회")
     public ResponseEntity<List<ReviewDTO.Response>> getAllReviews() {
         List<ReviewDTO.Response> reviewResponses = reviewService.getAllReviews();
         return ResponseEntity.ok(reviewResponses);
     }
 
-    @GetMapping("/{id}")
-    @Operation(summary = "특정 리뷰 조회")
-    public ResponseEntity<ReviewDTO.Response> getReviewById(@PathVariable Long id) {
+    @GetMapping("/review/get/{id}")
+    @Operation(summary = "[공통] 특정 리뷰 조회")
+    public ResponseEntity<ReviewDTO.Response> getReviewById(
+            @Parameter(description = "reviewId")
+            @PathVariable Long id) {
         ReviewDTO.Response reviewResponse = reviewService.getReviewById(id);
         return ResponseEntity.ok(reviewResponse);
     }
-    @PostMapping("")
-    @Operation(summary = "리뷰 작성")
-    public ResponseEntity<ReviewDTO.Response> createReview(@RequestBody ReviewDTO.Request reviewRequest) {
-        ReviewDTO.Response createdReview = reviewService.createReview(reviewRequest);
+    @PostMapping("/weddingplanner/review/create")
+    @Operation(summary = "[웨딩플래너] 리뷰 작성")
+    public ResponseEntity<ReviewDTO.Response> createReviewForWeddingPlanner(@RequestBody ReviewDTO.Request reviewRequest) {
+        ReviewDTO.Response createdReview = reviewService.createReviewForWeddingPlanner(reviewRequest);
         return ResponseEntity.ok(createdReview);
     }
 
-    @PostMapping("update/{id}")
-    @Operation(summary = "특정 리뷰 업데이트")
-    public ResponseEntity<ReviewDTO.Response> updateReview(@PathVariable Long id, @RequestBody ReviewDTO.Request reviewRequest) {
-        ReviewDTO.Response updatedReview = reviewService.modifyReview(id, reviewRequest);
+    @PostMapping("/customer/review/create")
+    @Operation(summary = "[신랑신부] 리뷰 작성")
+    public ResponseEntity<ReviewDTO.Response> createReviewForCustomer(@RequestBody ReviewDTO.Request reviewRequest) {
+        ReviewDTO.Response createdReview = reviewService.createReviewForCustomer(reviewRequest);
+        return ResponseEntity.ok(createdReview);
+    }
+
+    @PostMapping("/weddingplanner/review/update/{id}")
+    @Operation(summary = "[웨딩플래너] 특정 리뷰 업데이트")
+    public ResponseEntity<ReviewDTO.Response> updateReviewForWeddingPlanner(
+            @Parameter(description = "reviewId")
+            @PathVariable Long id, @RequestBody ReviewDTO.Request reviewRequest) {
+        ReviewDTO.Response updatedReview = reviewService.modifyReviewForWeddingPlanner(id, reviewRequest);
         return ResponseEntity.ok(updatedReview);
     }
 
-    @PostMapping("/delete/{id}")
-    @Operation(summary = "특정 리뷰 삭제")
-    public ResponseEntity<Void> deleteReview(@PathVariable Long id) {
-        reviewService.deleteReview(id);
+    @PostMapping("/customer/review/update/{id}")
+    @Operation(summary = "[신랑신부] 특정 리뷰 업데이트")
+    public ResponseEntity<ReviewDTO.Response> updateReviewForCustomer(
+            @Parameter(description = "reviewId")
+            @PathVariable Long id, @RequestBody ReviewDTO.Request reviewRequest) {
+        ReviewDTO.Response updatedReview = reviewService.modifyReviewForCustomer(id, reviewRequest);
+        return ResponseEntity.ok(updatedReview);
+    }
+
+    @PostMapping("/weddingplanner/review/delete/{id}")
+    @Operation(summary = "[웨딩플래너] 특정 리뷰 삭제")
+    public ResponseEntity<Void> deleteReviewForWeddingPlanner(
+            @Parameter(description = "reviewId")
+            @PathVariable Long id) {
+        reviewService.deleteReviewForWeddingPlanner(id);
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/soft-deleted")
-    @Operation(summary = "soft-deleted 리뷰 조회")
+    @PostMapping("/customer/review/delete/{id}")
+    @Operation(summary = "[신랑신부] 특정 리뷰 삭제")
+    public ResponseEntity<Void> deleteReview(
+            @Parameter(description = "reviewId")
+            @PathVariable Long id) {
+        reviewService.deleteReviewForCustomer(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/review/get/soft-deleted")
+    @Operation(summary = "[공통] soft-deleted 리뷰 조회")
     public ResponseEntity<List<ReviewDTO.Response>> getAllSoftDeleted() {
         List<ReviewDTO.Response> softDeletedReviews = reviewService.getAllSoftDeletedReviews();
         return ResponseEntity.ok(softDeletedReviews);
     }
 
-    @GetMapping("/customer/myreview")
-    @Operation(summary = "[예비신랑신부용] 내 리뷰 조회")
+    @GetMapping("/customer/review/get")
+    @Operation(summary = "[신랑신부] 내 리뷰 조회")
     public ResponseEntity<List<ReviewDTO.Response>> getMyReviewsForCustomer() {
         List<ReviewDTO.Response> myReviews = reviewService.getMyReviewsForCustomer();
         return ResponseEntity.ok(myReviews);
     }
 
-    @GetMapping("/weddingplanner/myreview")
-    @Operation(summary = "[웨딩플래너용] 내 리뷰 조회")
+    @GetMapping("/weddingplanner/review/get")
+    @Operation(summary = "[웨딩플래너] 내 리뷰 조회")
     public ResponseEntity<List<ReviewDTO.Response>> getMyReviewsForWeddingplanner() {
 
         List<ReviewDTO.Response> myReviews = reviewService.getMyReviewsForWeddingplanner();

--- a/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
+++ b/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
@@ -64,6 +64,9 @@ public class ReviewDTO {
     @Builder
     public static class Response {
 
+        @Schema(type = "long", example = "1")
+        private Long id;
+
         @Schema(type = "string", example = "name1")
         private String reviewerName;
 

--- a/demo/src/main/java/com/example/demo/review/service/ReviewService.java
+++ b/demo/src/main/java/com/example/demo/review/service/ReviewService.java
@@ -48,7 +48,7 @@ public class ReviewService {
 
     @Transactional
     public ReviewDTO.Response createReviewForWeddingPlanner(ReviewDTO.Request reviewRequest) {
-        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner().orElseThrow();
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
 
         reviewRequest.setWeddingPhotoUrls(reviewRequest.getWeddingPhotoUrls().stream()
                 .map(s3Uploader::getUniqueFilename)
@@ -79,7 +79,7 @@ public class ReviewService {
 
     @Transactional
     public ReviewDTO.Response createReviewForCustomer(ReviewDTO.Request reviewRequest) {
-        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer().orElseThrow();
+        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
 
         //Change image name to be unique
         reviewRequest.setWeddingPhotoUrls(reviewRequest.getWeddingPhotoUrls().stream()
@@ -111,13 +111,13 @@ public class ReviewService {
 
     @Transactional
     public ReviewDTO.Response modifyReviewForWeddingPlanner(Long id, ReviewDTO.Request reviewRequest) {
-        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner().orElseThrow();
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
 
         Review existingReview = reviewRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Review not found"));
 
         if (existingReview.getReviewerId() != weddingPlanner.getId()) {
-            throw new RuntimeException("권한이 없습니다.");
+            throw new RuntimeException("Not authorized to modify this review");
         }
         List<String> weddingPhotoUrls = existingReview.getWeddingPhotoUrls();
         if (weddingPhotoUrls != null) {
@@ -148,13 +148,13 @@ public class ReviewService {
 
     @Transactional
     public ReviewDTO.Response modifyReviewForCustomer(Long id, ReviewDTO.Request reviewRequest) {
-        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer().orElseThrow();
+        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
 
         Review existingReview = reviewRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Review not found"));
 
         if (existingReview.getReviewerId() != customer.getId()) {
-            throw new RuntimeException("권한이 없습니다.");
+            throw new RuntimeException("Not authorized to modify this review");
         }
 
         List<String> weddingPhotoUrls = existingReview.getWeddingPhotoUrls();
@@ -187,13 +187,13 @@ public class ReviewService {
 
     @Transactional
     public void deleteReviewForWeddingPlanner(Long id) {
-        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner().orElseThrow();
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
 
         Review review = reviewRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Review not found"));
 
         if (review.getReviewerId() != weddingPlanner.getId()) {
-            throw new RuntimeException("권한이 없습니다.");
+            throw new RuntimeException("Not authorized to delete this review");
         }
         List<String> weddingPhotoUrls = review.getWeddingPhotoUrls();
 
@@ -206,13 +206,13 @@ public class ReviewService {
 
     @Transactional
     public void deleteReviewForCustomer(Long id) {
-        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer().orElseThrow();
+        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
 
         Review review = reviewRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Review not found"));
 
         if (review.getReviewerId() != customer.getId()) {
-            throw new RuntimeException("권한이 없습니다.");
+            throw new RuntimeException("Not authorized to delete this review");
         }
         List<String> weddingPhotoUrls = review.getWeddingPhotoUrls();
 
@@ -230,14 +230,14 @@ public class ReviewService {
     }
 
     public List<ReviewDTO.Response> getMyReviewsForCustomer() throws UsernameNotFoundException {
-        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer().orElseThrow();
+        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
         return reviewRepository.findReviewsForCustomer(customer.getId()).stream()
                 .map(reviewMapper::entityToResponse)
                 .collect(Collectors.toList());
     }
 
     public List<ReviewDTO.Response> getMyReviewsForWeddingplanner() throws UsernameNotFoundException {
-        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner().orElseThrow();
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
 
         return reviewRepository.findReviewsForWeddingPlanner(weddingPlanner.getId()).stream()
                         .map(reviewMapper::entityToResponse)

--- a/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
+++ b/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
@@ -15,33 +15,33 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/wishlist")
+@RequestMapping("/api/v1")
 @Tag(name = "wishlist", description = "wishlist API")
 public class WishListController {
 
     private final WishListService wishListService;
 
-    @GetMapping("/get")
-    @Operation(summary = "위시리스트 목록 조회", description = "자신의 위시리스트 목록을 조회합니다.")
+    @GetMapping("/customer/wishlists/get")
+    @Operation(summary = "[신랑신부] 위시리스트 목록 조회", description = "customer가 자신의 위시리스트 목록을 조회합니다.")
     public ResponseEntity<List<PortfolioOverviewDTO.Response>> getWishListByMember(@RequestParam(value = "page", defaultValue = "0") int page,
                                                                             @RequestParam(value = "size", defaultValue = "10") int size){
         List<PortfolioOverviewDTO.Response> portfolioOverviews = wishListService.getWishListByMember(page, size);
         return ResponseEntity.ok(portfolioOverviews);
     }
 
-    @PostMapping("/post/{id}")
-    @Operation(summary = "위시리스트 추가", description = "자신이 원하는 포트폴리오를 위시리스트에 추가합니다.")
+    @PostMapping("/customer/wishlists/post/{id}")
+    @Operation(summary = "[신랑신부] 위시리스트 추가", description = "customer가 자신이 원하는 포트폴리오를 위시리스트에 추가합니다.")
     public ResponseEntity<Void> addWishList(
-            @Parameter(name = "id", description = "portfolio 의 id", in = ParameterIn.PATH)
+            @Parameter(description = "portfolioId")
             @PathVariable("id") Long portfolioId){
         wishListService.addWishList(portfolioId);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/delete/{id}")
-    @Operation(summary = "위시리스트 삭제", description = "자신의 위시리스트에서 포트폴리오를 삭제합니다.")
+    @PostMapping("/customer/wishlists/delete/{id}")
+    @Operation(summary = "[신랑신부] 위시리스트 삭제", description = "customer가 자신의 위시리스트에서 포트폴리오를 삭제합니다.")
     public ResponseEntity<Void> deleteWishList(
-            @Parameter(name = "id", description = "portfolio 의 id", in = ParameterIn.PATH)
+            @Parameter(description = "portfolioId")
             @PathVariable("id") Long portfolioId){
         wishListService.deleteWishList(portfolioId);
         return ResponseEntity.ok().build();

--- a/demo/src/main/java/com/example/demo/wishlist/service/WishListService.java
+++ b/demo/src/main/java/com/example/demo/wishlist/service/WishListService.java
@@ -28,7 +28,7 @@ public class WishListService {
     private final PortfolioMapper portfolioMapper;
 
     public List<PortfolioOverviewDTO.Response> getWishListByMember(int page, int size) {
-        Long memberId = memberService.getCurrentAuthenticatedCustomer().orElseThrow().getId();
+        Long memberId = memberService.getCurrentAuthenticatedCustomer().getId();
         PageRequest pageRequest = PageRequest.of(page, size, Sort.by("createdAt").ascending());
         Page<WishList> wishLists = wishListRepository.findAllByCustomerId(memberId, pageRequest);
         List<PortfolioOverviewDTO.Response> portfolioOverviewDtos = wishLists.stream()
@@ -40,7 +40,7 @@ public class WishListService {
 
     @Transactional
     public void addWishList(Long portfolioId) {
-        Customer customer = memberService.getCurrentAuthenticatedCustomer().orElseThrow();
+        Customer customer = memberService.getCurrentAuthenticatedCustomer();
         if (wishListRepository.existsByCustomerIdAndPortfolioId(customer.getId(), portfolioId)) {
             return;
         }
@@ -54,7 +54,7 @@ public class WishListService {
 
     @Transactional
     public void deleteWishList(Long portfolioId) {
-        Customer customer = memberService.getCurrentAuthenticatedCustomer().orElseThrow();
+        Customer customer = memberService.getCurrentAuthenticatedCustomer();
         if (wishListRepository.existsByCustomerIdAndPortfolioId(customer.getId(), portfolioId)) {
             return;
         }


### PR DESCRIPTION
### PR 요약
리팩토링 (swagger, controller QA, exception 핸들링)

### 변경 사항
[리팩토링]
1. Exception 
- Exception을 이중으로 처리하지 않도록 처리하였습니다.
- 인증 처리와 관련된 UsernameNotFoundException 예외를 전역적으로 처리하도록 구현하였습니다.

2. 스웨거 양식 통일
api/v1/{사용하는주체}/{사용하는 대상}/{메소드}/{내용}
ex.
/api/v1/weddingplanner/portfolios/delete/{portfolioId}
/api/v1/customer/wishlists/post/{portfolioId}

3. 간단한 system.out.println() 코드 삭제

4. S3 이미지 삭제 시 S3에 이미지가 있는지 확인 후 삭제하도록 리팩토링
간단한 Swagger QA 진행하면서 문제가 있을 수 있는 구간을 리팩토링 하였습니다.

5. weddingplanner 및 customer API 분리
Review를 업로드/수정/삭제 하는 메소드와 같이 customer과 weddingplanner 둘 다 접근하는 API는 따로 구현하였습니다.

[오류 해결]
순환 참조 오류를 해결하였습니다.
Portfolio - WeddingPlanner 간 OneToOne 매핑 의존도를 없애는 형태로 구현하였습니다.

### 참고 사항
- [ ] 추후 Portfolio Entity 관련 회의가 필요해보입니다. (지연로딩 관련 문제, 연관관계 매핑 문제)
- [ ] 채팅과 관련한 chatController의 경우에는 아직 리팩토링을 진행하지 않았습니다. 
다만 chatService 코드가 일부 바뀌었으므로 확인 부탁드립니다 !
- [ ] 오류 메시지와 로깅 모두 영어 포맷으로 진행하도록 하겠습니다. 
