### PR TITLE
Feat/Enter chatroom and send message

### DIFF
--- a/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
@@ -24,6 +24,12 @@ public class ChatRoomController {
         ChatRoomDTO.Response createdChatRoom = chatRoomService.enterChatRoomByPortfolioId(portfolioId);
         return ResponseEntity.status(201).body(createdChatRoom);
     }
+    @PostMapping("/{chatRoomId}")
+    @Operation(summary = "[웨딩플래너] 채팅방 아이디로 채팅방 입장")
+    public ResponseEntity<ChatRoomDTO.Response> getChatRoomByIdForWeddingPlanner(@PathVariable Long chatRoomId) {
+        ChatRoomDTO.Response chatRoomByChatRoomId = chatRoomService.getChatRoomByChatRoomId(chatRoomId);
+        return ResponseEntity.status(200).body(chatRoomByChatRoomId);
+    }
 
     @GetMapping("")
     @Operation(summary = "현재 사용자의 모든 채팅방 조회")

--- a/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
@@ -7,10 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,8 +19,8 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
     @PostMapping("/{portfolioId}")
-    @Operation(summary = "포트폴리오 아이디로 채팅방 입장(생성 및 입장)")
-    public ResponseEntity<ChatRoomDTO.Response> enterChatRoomByPortfolioId(Long portfolioId) {
+    @Operation(summary = "[신랑신부] 포트폴리오 아이디로 채팅방 입장(생성 및 입장)")
+    public ResponseEntity<ChatRoomDTO.Response> enterChatRoomByPortfolioId(@PathVariable Long portfolioId) {
         ChatRoomDTO.Response createdChatRoom = chatRoomService.enterChatRoomByPortfolioId(portfolioId);
         return ResponseEntity.status(201).body(createdChatRoom);
     }

--- a/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
@@ -1,21 +1,57 @@
 package com.example.demo.chat.controller;
 
+import com.example.demo.chat.dto.MessageDTO;
+import com.example.demo.chat.service.ChatRoomService;
+import com.example.demo.chat.service.MessageService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+//@RequestMapping("/api/v1/message")
+@Tag(name = "message", description = "메세지 API")
 public class MessageController {
-//    private final SimpMessagingTemplate template; //특정 Broker 로 메세지를 전달
-//    private final ChatService chatService;
-//
-//    // stompConfig 에서 설정한 applicationDestinationPrefixes 와 @MessageMapping 경로가 병합됨 (/pub + ...)
-//    // /pub/chat/enter 에 메세지가 오면 동작
-//    @MessageMapping(value = "/chat/enter")
-//    public void enter(ChatRequestDto message){ // 채팅방 입장
-//        message.setMessage(message.getWriter() + "님이 채팅방에 참여하였습니다.");
-//        template.convertAndSend("/sub/chat/" + message.getRoomId(), message);
-//    }
-//
-//    // /pub/chat/message 에 메세지가 오면 동작
-//    @MessageMapping(value = "/chat/message")
-//    public void message(ChatRequestDto message){
-//        ChatResponseDto savedMessage = chatService.saveMessage(message);
-//        template.convertAndSend("/sub/chat/" + savedMessage.getRoomId(), savedMessage);
-//    }
+    private final SimpMessagingTemplate template; //특정 Broker 로 메세지를 전달
+    private final MessageService messageService;
+
+    private final ChatRoomService chatRoomService;
+
+    @MessageMapping(value = "/connect")
+    public void connect(MessageDTO.Request messageRequest){
+        // TODO : 프로그램 실행 시, 모든 채팅방 연결.
+        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
+    }
+
+    @MessageMapping(value = "/disconnect")
+    public void disconnect(MessageDTO.Request messageRequest){
+        // TODO : 강제 종료되는 경우에만 실행됨. 후순위 개발.
+        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
+    }
+
+    @MessageMapping(value = "/enter")
+    public void enterByChatRoomList(MessageDTO.Request messageRequest){
+        // TODO : 방 입장 시, 읽음 처리 필요(readFlag(lastReadMessageId) 갱신 필요)
+        // TODO(not fixed) : 방 입장 시, 상태 ENTER로 변경 필요
+        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
+    }
+
+    @MessageMapping(value = "/send")
+    public void send(MessageDTO.Request messageRequest){
+        // TODO : readFlag(lastReadMessageId) 갱신 필요
+
+        messageService.saveMessage(messageRequest);
+
+        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
+    }
+
+    @MessageMapping(value = "/leave")
+    public void leave(MessageDTO.Request messageRequest) {
+        // TODO : 방 퇴장 시, 상태 LEAVE로 변경 필요
+
+        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
+    }
+
 }

--- a/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
@@ -7,11 +7,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-//@RequestMapping("/api/v1/message")
+@RequestMapping("/ws/v1/message")
 @Tag(name = "message", description = "메세지 API")
 public class MessageController {
     private final SimpMessagingTemplate template; //특정 Broker 로 메세지를 전달

--- a/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
@@ -40,7 +40,7 @@ public class MessageController {
 
     @MessageMapping(value = "/send")
     public void send(MessageDTO.Request messageRequest){
-        // TODO : readFlag(lastReadMessageId) 갱신 필요
+        // TODO : readFlag(lastReadMessㄴageId) 갱신 필요
 
         messageService.saveMessage(messageRequest);
 

--- a/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
@@ -34,13 +34,14 @@ public class MessageController {
     @MessageMapping(value = "/enter")
     public void enterByChatRoomList(MessageDTO.Request messageRequest){
         // TODO : 방 입장 시, 읽음 처리 필요(readFlag(lastReadMessageId) 갱신 필요)
+        // TODO : messages 정보 받아와야 함.
         // TODO(not fixed) : 방 입장 시, 상태 ENTER로 변경 필요
         template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
     }
 
     @MessageMapping(value = "/send")
     public void send(MessageDTO.Request messageRequest){
-        // TODO : readFlag(lastReadMessㄴageId) 갱신 필요
+        // TODO : readFlag(lastReadMessageId) 갱신 필요
 
         messageService.saveMessage(messageRequest);
 

--- a/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
@@ -37,9 +37,4 @@ public class ChatRoom extends BaseTimeEntity {
     @JoinColumn(name = "weddingplanner_id")
     private WeddingPlanner weddingPlanner;
 
-//    @OneToMany(mappedBy = "chatRoom")
-//    @OrderBy("createdAt asc")
-//    private List<Message> messages = new ArrayList<>();
-
-
 }

--- a/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
@@ -34,7 +34,7 @@ public class ChatRoom extends BaseTimeEntity {
     private Customer customer;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "wedding_planner_id")
+    @JoinColumn(name = "weddingplanner_id")
     private WeddingPlanner weddingPlanner;
 
     @OneToMany(mappedBy = "chatRoom")

--- a/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
@@ -37,19 +37,9 @@ public class ChatRoom extends BaseTimeEntity {
     @JoinColumn(name = "weddingplanner_id")
     private WeddingPlanner weddingPlanner;
 
-    @OneToMany(mappedBy = "chatRoom")
-    @OrderBy("createdAt asc")
-    private List<Message> messages = new ArrayList<>();
-
 //    @OneToMany(mappedBy = "chatRoom")
 //    @OrderBy("createdAt asc")
-//    private Map<MemberRole, ReadFlag> readFlags;
-//
-//    public void addReadFlag(MemberRole memberRole, ReadFlag readFlag) {
-//        if (this.readFlags == null) {
-//            this.readFlags = new HashMap<>();
-//        }
-//        readFlag.setChatRoom(this);
-//        this.readFlags.put(memberRole, readFlag);
-//    }
+//    private List<Message> messages = new ArrayList<>();
+
+
 }

--- a/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
@@ -41,14 +41,15 @@ public class ChatRoom extends BaseTimeEntity {
     @OrderBy("createdAt asc")
     private List<Message> messages = new ArrayList<>();
 
-    @OneToMany(mappedBy = "chatRoom")
-    @OrderBy("createdAt asc")
-    private Map<MemberRole, ReadFlag> readFlags;
-
-    public void addReadFlag(MemberRole memberRole, ReadFlag readFlag) {
-        if (this.readFlags == null) {
-            this.readFlags = new HashMap<>();
-        }
-        this.readFlags.put(memberRole, readFlag);
-    }
+//    @OneToMany(mappedBy = "chatRoom")
+//    @OrderBy("createdAt asc")
+//    private Map<MemberRole, ReadFlag> readFlags;
+//
+//    public void addReadFlag(MemberRole memberRole, ReadFlag readFlag) {
+//        if (this.readFlags == null) {
+//            this.readFlags = new HashMap<>();
+//        }
+//        readFlag.setChatRoom(this);
+//        this.readFlags.put(memberRole, readFlag);
+//    }
 }

--- a/demo/src/main/java/com/example/demo/chat/domain/Message.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/Message.java
@@ -28,7 +28,6 @@ public class Message extends BaseTimeEntity {
 
     private MessageType messageType;
     private String contents;
-//    private MemberRole memberRole;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")

--- a/demo/src/main/java/com/example/demo/chat/domain/Message.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/Message.java
@@ -1,6 +1,7 @@
 package com.example.demo.chat.domain;
 
 import com.example.demo.base.BaseTimeEntity;
+import com.example.demo.enums.chat.MessageType;
 import com.example.demo.enums.member.MemberRole;
 import com.example.demo.member.domain.Customer;
 import jakarta.persistence.*;
@@ -25,8 +26,9 @@ public class Message extends BaseTimeEntity {
     @Builder.Default
     private boolean isDeleted = Boolean.FALSE;
 
+    private MessageType messageType;
     private String contents;
-    private MemberRole memberRole;
+//    private MemberRole memberRole;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")

--- a/demo/src/main/java/com/example/demo/chat/domain/ReadFlag.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/ReadFlag.java
@@ -4,6 +4,7 @@ import com.example.demo.base.BaseTimeEntity;
 import com.example.demo.enums.member.MemberRole;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Setter

--- a/demo/src/main/java/com/example/demo/chat/dto/MessageDTO.java
+++ b/demo/src/main/java/com/example/demo/chat/dto/MessageDTO.java
@@ -1,5 +1,6 @@
 package com.example.demo.chat.dto;
 
+import com.example.demo.enums.chat.MessageType;
 import lombok.*;
 
 public class MessageDTO {
@@ -13,6 +14,11 @@ public class MessageDTO {
     public static class Request {
         private Long id;
 
+        private MessageType messageType;
+
+        private String contents;
+
+        private Long chatRoomId;
     }
 
     @Getter
@@ -23,5 +29,27 @@ public class MessageDTO {
     @Builder
     public static class Response {
         private Long id;
+
+        private MessageType messageType;
+
+        private String contents;
+
+        private Long chatRoomId;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PortfolioRequest {
+        private Long id;
+
+        private MessageType messageType;
+
+        private String contents;
+
+        private Long portfolioId;
     }
 }

--- a/demo/src/main/java/com/example/demo/chat/dto/ReadFlagDTO.java
+++ b/demo/src/main/java/com/example/demo/chat/dto/ReadFlagDTO.java
@@ -1,14 +1,10 @@
 package com.example.demo.chat.dto;
 
-import com.example.demo.chat.domain.Message;
-import com.example.demo.chat.domain.ReadFlag;
+import com.example.demo.chat.domain.ChatRoom;
 import com.example.demo.enums.member.MemberRole;
 import lombok.*;
 
-import java.util.List;
-import java.util.Map;
-
-public class ChatRoomDTO {
+public class ReadFlagDTO {
 
     @Getter
     @Setter
@@ -19,11 +15,13 @@ public class ChatRoomDTO {
     public static class Request {
         private Long id;
 
-        private Long portfolioId;
+        private MemberRole memberRole;
 
-        private Long weddingPlannerId;
+        private ChatRoom chatRoom;
 
+        private Long lastReadMessageId;
     }
+
 
     @Getter
     @Setter
@@ -34,10 +32,8 @@ public class ChatRoomDTO {
     public static class Response {
         private Long id;
 
-        private List<Message> messages;
+        private MemberRole memberRole;
 
-        private Long customerLastReadMessageId;
-
-        private Long weddingPlannerLastReadMessageId;
+        private Long lastReadMessageId;
     }
 }

--- a/demo/src/main/java/com/example/demo/chat/mapper/ReadFlagMapper.java
+++ b/demo/src/main/java/com/example/demo/chat/mapper/ReadFlagMapper.java
@@ -1,0 +1,22 @@
+package com.example.demo.chat.mapper;
+
+import com.example.demo.chat.domain.Message;
+import com.example.demo.chat.domain.ReadFlag;
+import com.example.demo.chat.dto.MessageDTO;
+import com.example.demo.chat.dto.ReadFlagDTO;
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface ReadFlagMapper {
+    com.example.demo.chat.mapper.ReadFlagMapper INSTANCE = Mappers.getMapper(com.example.demo.chat.mapper.ReadFlagMapper.class);
+
+    @Mapping(target = "id", ignore = true)
+    ReadFlag requestToEntity(ReadFlagDTO.Request readFlagRequest);
+
+    ReadFlagDTO.Response entityToResponse(ReadFlag readFlag);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    ReadFlag updateFromRequest(ReadFlagDTO.Request readFlagRequest, @MappingTarget ReadFlag readFlag);
+
+}

--- a/demo/src/main/java/com/example/demo/chat/repository/MessageRepository.java
+++ b/demo/src/main/java/com/example/demo/chat/repository/MessageRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
-    Optional<List<Message>> findByChatRoomId(Long chatRoomId);
+    List<Message> findByChatRoomId(Long chatRoomId);
 
     @Transactional
     @Modifying

--- a/demo/src/main/java/com/example/demo/chat/repository/MessageRepository.java
+++ b/demo/src/main/java/com/example/demo/chat/repository/MessageRepository.java
@@ -11,9 +11,12 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    Optional<List<Message>> findByChatRoomId(Long chatRoomId);
 
     @Transactional
     @Modifying

--- a/demo/src/main/java/com/example/demo/chat/repository/ReadFlagRepository.java
+++ b/demo/src/main/java/com/example/demo/chat/repository/ReadFlagRepository.java
@@ -1,6 +1,7 @@
 package com.example.demo.chat.repository;
 
 import com.example.demo.chat.domain.ReadFlag;
+import com.example.demo.enums.member.MemberRole;
 import com.example.demo.portfolio.domain.Portfolio;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,9 +11,11 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReadFlagRepository extends JpaRepository<ReadFlag, Long> {
+    Optional<ReadFlag> findByChatRoomIdAndMemberRole(Long chatRoomId, MemberRole memberRole);
 
     @Transactional
     @Modifying

--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -5,6 +5,7 @@ import com.example.demo.chat.domain.ChatRoom;
 import com.example.demo.chat.domain.ReadFlag;
 import com.example.demo.chat.dto.ChatRoomDTO;
 import com.example.demo.chat.dto.ChatRoomOverviewDTO;
+import com.example.demo.chat.dto.ReadFlagDTO;
 import com.example.demo.chat.mapper.ChatRoomMapper;
 import com.example.demo.chat.repository.ChatRoomRepository;
 import com.example.demo.chat.repository.ReadFlagRepository;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -73,7 +75,6 @@ public class ChatRoomService {
         readFlagRepository.save(weddingPlannerReadFlag);
 
         return chatRoomMapper.entityToResponse(chatRoom);
-
     }
 
     public List<ChatRoomOverviewDTO.Response> getCurrentUsersAllChatRoom() {
@@ -100,7 +101,16 @@ public class ChatRoomService {
     public ChatRoomDTO.Response getChatRoomByCustomerAndWeddingPlanner(Customer customer, WeddingPlanner weddingPlanner) {
         ChatRoom chatRoom = chatRoomRepository.findByCustomerIdAndWeddingPlannerId(customer.getId(), weddingPlanner.getId());
 
-        return chatRoomMapper.entityToResponse(chatRoom);
+        ReadFlag customerReadFlag = readFlagRepository.findByChatRoomIdAndMemberRole(chatRoom.getId(), MemberRole.CUSTOMER)
+                .orElseThrow(() -> new RuntimeException("ReadFlag not found"));
+        ReadFlag weddingPlannerReadFlag = readFlagRepository.findByChatRoomIdAndMemberRole(chatRoom.getId(), MemberRole.WEDDING_PLANNER)
+                .orElseThrow(() -> new RuntimeException("ReadFlag not found"));
+
+        ChatRoomDTO.Response response = chatRoomMapper.entityToResponse(chatRoom);
+        response.setCustomerLastReadMessageId(customerReadFlag.getLastReadMessageId());
+        response.setWeddingPlannerLastReadMessageId(weddingPlannerReadFlag.getLastReadMessageId());
+
+        return response;
     }
 
     public void deleteChatRoom(Long chatRoomId) {

--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -53,7 +53,8 @@ public class ChatRoomService {
             return createChatRoomByPortfolioId(customer, weddingPlanner);
         }
         System.out.println("ChatRoom exist");
-        return getChatRoomByCustomerAndWeddingPlanner(customer, weddingPlanner);
+        Long chatRoomId = getChatRoomIdByCustomerAndWeddingPlanner(customer, weddingPlanner);
+        return getChatRoomByChatRoomId(chatRoomId);
     }
 
     public ChatRoomDTO.Response createChatRoomByPortfolioId(Customer customer, WeddingPlanner weddingPlanner) {
@@ -106,8 +107,14 @@ public class ChatRoomService {
                 .collect(Collectors.toList());
     }
 
-    public ChatRoomDTO.Response getChatRoomByCustomerAndWeddingPlanner(Customer customer, WeddingPlanner weddingPlanner) {
+    public Long getChatRoomIdByCustomerAndWeddingPlanner(Customer customer, WeddingPlanner weddingPlanner) {
         ChatRoom chatRoom = chatRoomRepository.findByCustomerIdAndWeddingPlannerId(customer.getId(), weddingPlanner.getId());
+        return chatRoom.getId();
+    }
+
+    public ChatRoomDTO.Response getChatRoomByChatRoomId(Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new RuntimeException("ChatRoom not found"));
 
         ReadFlag customerReadFlag = readFlagRepository.findByChatRoomIdAndMemberRole(chatRoom.getId(), MemberRole.CUSTOMER)
                 .orElseThrow(() -> new RuntimeException("ReadFlag not found"));
@@ -124,6 +131,7 @@ public class ChatRoomService {
 
         return response;
     }
+
 
     public void deleteChatRoom(Long chatRoomId) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)

--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -92,8 +92,7 @@ public class ChatRoomService {
                     Portfolio portfolio = portfolioService.getPortfolioByWeddingPlannerId(chatRoom.getWeddingPlanner().getId());
                     PortfolioDTO.Response portfolioResponse = portfolioService.getPortfolioById(portfolio.getId());
 
-                    List<Message> messages = messageRepository.findByChatRoomId(chatRoom.getId())
-                            .orElse(List.of());
+                    List<Message> messages = messageRepository.findByChatRoomId(chatRoom.getId());
 
                     return ChatRoomOverviewDTO.Response.builder()
                             .weddingPlannerProfileImageUrl(portfolioResponse.getWeddingPlanner().getProfileImageUrl())
@@ -121,8 +120,7 @@ public class ChatRoomService {
         ReadFlag weddingPlannerReadFlag = readFlagRepository.findByChatRoomIdAndMemberRole(chatRoom.getId(), MemberRole.WEDDING_PLANNER)
                 .orElseThrow(() -> new RuntimeException("ReadFlag not found"));
 
-        List<Message> messages = messageRepository.findByChatRoomId(chatRoom.getId())
-                .orElse(List.of());
+        List<Message> messages = messageRepository.findByChatRoomId(chatRoom.getId());
 
         ChatRoomDTO.Response response = chatRoomMapper.entityToResponse(chatRoom);
         response.setMessages(messages);

--- a/demo/src/main/java/com/example/demo/chat/service/MessageService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/MessageService.java
@@ -20,12 +20,12 @@ public class MessageService {
     private final ChatRoomService chatRoomService;
     private final ChatRoomMapper chatRoomMapper = ChatRoomMapper.INSTANCE;
 
-
     public MessageDTO.Response saveMessage(MessageDTO.Request messageRequest) {
         ChatRoom chatRoom = chatRoomService.getChatRoomById(messageRequest.getChatRoomId());
         Message message = messageMapper.requestToEntity(messageRequest);
         message.setChatRoom(chatRoom);
         Message savedMessage = messageRepository.save(message);
+
         return messageMapper.entityToResponse(savedMessage);
     }
 }

--- a/demo/src/main/java/com/example/demo/chat/service/MessageService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/MessageService.java
@@ -1,6 +1,11 @@
 package com.example.demo.chat.service;
 
 
+import com.example.demo.chat.domain.ChatRoom;
+import com.example.demo.chat.domain.Message;
+import com.example.demo.chat.dto.ChatRoomDTO;
+import com.example.demo.chat.dto.MessageDTO;
+import com.example.demo.chat.mapper.ChatRoomMapper;
 import com.example.demo.chat.mapper.MessageMapper;
 import com.example.demo.chat.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,4 +16,16 @@ import org.springframework.stereotype.Service;
 public class MessageService {
     private final MessageRepository messageRepository;
     private final MessageMapper messageMapper = MessageMapper.INSTANCE;
+
+    private final ChatRoomService chatRoomService;
+    private final ChatRoomMapper chatRoomMapper = ChatRoomMapper.INSTANCE;
+
+
+    public MessageDTO.Response saveMessage(MessageDTO.Request messageRequest) {
+        ChatRoom chatRoom = chatRoomService.getChatRoomById(messageRequest.getChatRoomId());
+        Message message = messageMapper.requestToEntity(messageRequest);
+        message.setChatRoom(chatRoom);
+        Message savedMessage = messageRepository.save(message);
+        return messageMapper.entityToResponse(savedMessage);
+    }
 }

--- a/demo/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -27,23 +27,23 @@ public class SecurityConfig{
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorize -> authorize
-                            .anyRequest().permitAll() //개발 단계에서 모든 요청을 허용
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(authorize -> authorize
+                        .anyRequest().permitAll() //개발 단계에서 모든 요청을 허용
 //                        .requestMatchers("/api/v1/member/token").permitAll()
 //                        .requestMatchers(HttpMethod.GET,"/swagger-ui/*", "/favicon.ico","/swagger-resources/**","/v3/api-docs/**").permitAll()
 //                        .requestMatchers(HttpMethod.GET,"/api/v1/portfolio/**").hasRole("USER") //USER 권한을 가진 사용자들이 접근 가능한 METHOD 및 URL 설정
 //                        .anyRequest().authenticated()
-                );
+            );
         return http.build();
     }
 
     @Bean
     public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
         http
-                .getSharedObject(AuthenticationManagerBuilder.class)
-                .userDetailsService(customUserDetailsService);
+            .getSharedObject(AuthenticationManagerBuilder.class)
+            .userDetailsService(customUserDetailsService);
         return http.getSharedObject(AuthenticationManager.class);
     }
 }

--- a/demo/src/main/java/com/example/demo/config/WebSocketBrokerConfig.java
+++ b/demo/src/main/java/com/example/demo/config/WebSocketBrokerConfig.java
@@ -1,6 +1,7 @@
 package com.example.demo.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -25,5 +26,10 @@ public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/stomp/chat")
                 .setAllowedOrigins("*");
     }
+//    TODO : header jwt interceptor
+//    @Override
+//    public void configureClientInboundChannel(ChannelRegistration registration) {
+//        registration.interceptors(new FilterChannelInterceptor());
+//    }
 
 }

--- a/demo/src/main/java/com/example/demo/dummy/DataLoader.java
+++ b/demo/src/main/java/com/example/demo/dummy/DataLoader.java
@@ -94,8 +94,7 @@ public class DataLoader implements CommandLineRunner {
                 .wishListCount(0)
                 .build();
 
-        portfolioRepository.save(portfolio1);
-        portfolioRepository.save(portfolio2);
+
 
         // Create Reviews
         List<String> reviewTags1 = Arrays.asList("tag1", "tag2");
@@ -138,10 +137,9 @@ public class DataLoader implements CommandLineRunner {
                 .tags(reviewTags2)
                 .weddingPhotoUrls(reviewPhotos2)
                 .radar(reviewRadar2)
+                .portfolio(portfolio1)
                 .build();
 
-        reviewRepository.save(review1);
-        reviewRepository.save(review2);
 
         Customer customer1 = Customer.builder()
                 .name("Clara")
@@ -164,6 +162,12 @@ public class DataLoader implements CommandLineRunner {
         customerRepository.save(customer1);
         customerRepository.save(customer2);
         weddingPlannerRepository.save(planner1);
+
+
+        portfolio1.setWeddingPlanner(planner1);
+
+        portfolioRepository.save(portfolio1);
+        portfolioRepository.save(portfolio2);
 
 //        Customer customer1 = customerRepository.findByName("Clara");
 //        Customer customer2 = customerRepository.findByName("Jeff");

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -119,4 +119,9 @@ public class CustomUserDetailsService implements UserDetailsService {
         return weddingPlannerMapper.entityToMypageDTOResponse(weddingPlanner);
 
     }
+
+    public WeddingPlanner getWeddingPlannerById(Long weddingPlannerId) {
+        return weddingPlannerRepository.findById(weddingPlannerId)
+                .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
+    }
 }

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -38,8 +38,8 @@ public class PortfolioService {
                 .collect(Collectors.toList());
     }
 
-    public PortfolioDTO.Response getPortfolioById(Long id) {
-        Portfolio portfolio = portfolioRepository.findById(id)
+    public PortfolioDTO.Response getPortfolioById(Long portfolioId) {
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new RuntimeException("Portfolio not found"));
         String CloudFrontImageUrl = s3Uploader.getImageUrl(portfolio.getProfileImageUrl());
         portfolio.setProfileImageUrl(CloudFrontImageUrl);


### PR DESCRIPTION
### PR 요약
기능 개발(채팅방 입장, 메세지 전송)

### 변경 사항
**Feature**
채팅방 개설, 메세지 전송시 해당하는 채팅방 id를 담은 message가 저장됩니다.
- STOMP 우선 전송 후 DB 저장

**Refactoring**
포폴 화면을 통해서 채팅방 입장하는 경우와, 채팅방 목록에서 채팅방 입장하는 경우의 API를 통일했습니다.(유저만 구분)
  - Customer : enterChatRoomByPortfolioId
  - WeddingPlanner : getChatRoomByIdForWeddingPlanner

**Resolving**
ChatRoom-ReadFlag, ChatRoom-Message 간 순환 참조 해결.
- ReadFlag, Message가 각각 ChatRoom에 대한 속성을 소유하도록 변경.
- ChatRoom에서 ReadFlag/Message가 필요할 경우, ReadFlag/Message Repository에서 ChatRoomId 기반으로 검색할 수 있도록 변경.

### 참고 사항
- 순환 참조한 방식에 대한 피드백 부탁드려요! 더 좋은 방법이 있을지 궁금하네요.
- MessageController에 ReadFlag와의 상호작용 TODO 정리해두었습니다. 