### PR TITLE
fix/standardize controller urls in swagger

### DIFF
--- a/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
@@ -13,32 +13,32 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/chatroom")
 @Tag(name = "chatroom", description = "채팅방 API")
 public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
-    @PostMapping("/customer/chatroom/{portfolioId}")
+    @PostMapping("/customer/{portfolioId}")
     @Operation(summary = "[신랑신부] 포트폴리오 아이디로 채팅방 입장(생성 및 입장)")
     public ResponseEntity<ChatRoomDTO.Response> enterChatRoomByPortfolioIdForCustomer(@PathVariable Long portfolioId) {
         ChatRoomDTO.Response createdChatRoom = chatRoomService.enterChatRoomByPortfolioId(portfolioId);
         return ResponseEntity.status(201).body(createdChatRoom);
     }
-    @PostMapping("/weddingplanner/chatroom/{chatRoomId}")
+    @PostMapping("/weddingplanner/{chatRoomId}")
     @Operation(summary = "[웨딩플래너] 채팅방 아이디로 채팅방 입장")
     public ResponseEntity<ChatRoomDTO.Response> getChatRoomByIdForWeddingPlanner(@PathVariable Long chatRoomId) {
         ChatRoomDTO.Response chatRoomByChatRoomId = chatRoomService.getChatRoomByChatRoomId(chatRoomId);
         return ResponseEntity.status(200).body(chatRoomByChatRoomId);
     }
 
-    @GetMapping("/customer/chatroom/get")
+    @GetMapping("/customer/all")
     @Operation(summary = "[신랑신부] 현재 모든 채팅방 조회")
     public ResponseEntity<List<ChatRoomOverviewDTO.Response>> getAllChatRoomForCustomer() {
         List<ChatRoomOverviewDTO.Response> currentUsersAllChatRoom = chatRoomService.getCustomersAllChatRoom();
         return ResponseEntity.status(200).body(currentUsersAllChatRoom);
     }
 
-    @GetMapping("/weddingplanner/chatroom/get")
+    @GetMapping("/weddingplanner/all")
     @Operation(summary = "[웨딩플래너] 현재 모든 채팅방 조회")
     public ResponseEntity<List<ChatRoomOverviewDTO.Response>> getAllChatRoomForWeddingPlanner() {
         List<ChatRoomOverviewDTO.Response> currentUsersAllChatRoom = chatRoomService.getWeddingPlannersAllChatRoom();
@@ -47,7 +47,7 @@ public class ChatRoomController {
 
     // TODO : 현재 유저만 나가야 함.
     // TODO : 메소드 명, API route 변경
-    @PostMapping("/delete/{chatRoomId}")
+    @PostMapping("/shared/delete/{chatRoomId}")
     @Operation(summary = "특정 채팅방 나가기")
     public ResponseEntity<Void> deleteChatRoom(Long chatRoomId) {
         chatRoomService.deleteChatRoom(chatRoomId);

--- a/demo/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -30,11 +30,12 @@ public class SecurityConfig{
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(authorize -> authorize
-                        .anyRequest().permitAll() //개발 단계에서 모든 요청을 허용
-//                        .requestMatchers("/api/v1/member/token").permitAll()
-//                        .requestMatchers(HttpMethod.GET,"/swagger-ui/*", "/favicon.ico","/swagger-resources/**","/v3/api-docs/**").permitAll()
-//                        .requestMatchers(HttpMethod.GET,"/api/v1/portfolio/**").hasRole("USER") //USER 권한을 가진 사용자들이 접근 가능한 METHOD 및 URL 설정
-//                        .anyRequest().authenticated()
+                    .requestMatchers("/api/v1/auth/shared/create").permitAll()
+                    .requestMatchers("/api/v1/*/weddingplanner/**").hasRole("WEDDING_PLANNER")
+                    .requestMatchers("/api/v1/*/customer/**").hasRole("CUSTOMER")
+                    .requestMatchers("/api/v1/*/shared/**").hasAnyRole("CUSTOMER","WEDDING_PLANNER")
+                    .requestMatchers("/swagger-ui/*", "/favicon.ico","/swagger-resources/**","/v3/api-docs/**").permitAll()
+                    .anyRequest().authenticated()
             );
         return http.build();
     }

--- a/demo/src/main/java/com/example/demo/member/controller/MemberController.java
+++ b/demo/src/main/java/com/example/demo/member/controller/MemberController.java
@@ -19,7 +19,7 @@ public class MemberController {
     private final CustomUserDetailsService customUserDetailsService;
 
     @PostMapping("/auth/shared/create")
-    @Operation(summary = "[공통] 토큰이 없을 때 유저 생성", description = "CUSTOMER 또는 WEDDINGPLANNER로 권한을 요청합니다.")
+    @Operation(summary = "[공통] 토큰이 없을 때 유저 생성", description = "ROLE_CUSTOMER 또는 ROLE_WEDDINGPLANNER로 권한을 요청합니다.")
     public ResponseEntity<AuthDTO.Response> createMember(@RequestBody AuthDTO.Request customerAuthRequest){
         AuthDTO.Response createdMember = customUserDetailsService.join(customerAuthRequest.getRole());
         return ResponseEntity.status(201).body(createdMember);

--- a/demo/src/main/java/com/example/demo/member/controller/MemberController.java
+++ b/demo/src/main/java/com/example/demo/member/controller/MemberController.java
@@ -18,7 +18,7 @@ public class MemberController {
 
     private final CustomUserDetailsService customUserDetailsService;
 
-    @PostMapping("/auth/create")
+    @PostMapping("/auth/shared/create")
     @Operation(summary = "[공통] 토큰이 없을 때 유저 생성", description = "CUSTOMER 또는 WEDDINGPLANNER로 권한을 요청합니다.")
     public ResponseEntity<AuthDTO.Response> createMember(@RequestBody AuthDTO.Request customerAuthRequest){
         AuthDTO.Response createdMember = customUserDetailsService.join(customerAuthRequest.getRole());
@@ -26,14 +26,14 @@ public class MemberController {
     }
 
     @ExceptionHandler(MissingRequestHeaderException.class)
-    @GetMapping("/customer/mypage/get")
+    @GetMapping("/mypage/customer/me")
     @Operation(summary = "[신랑신부] 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")
     public ResponseEntity<MypageDTO.CustomerResponse> getCustomerMyPage(){
         MypageDTO.CustomerResponse myPage = customUserDetailsService.getCustomerMyPage();
         return ResponseEntity.status(200).body(myPage);
     }
 
-    @GetMapping("/weddingplanner/mypage/get")
+    @GetMapping("/mypage/weddingplanner/me")
     @Operation(summary = "[웨딩플래너] 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")
     public ResponseEntity<MypageDTO.WeddingPlannerResponse> getWeddingPlannerMyPage(){
         MypageDTO.WeddingPlannerResponse myPage = customUserDetailsService.getWeddingPlannerMyPage();

--- a/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
+++ b/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
@@ -1,7 +1,6 @@
 package com.example.demo.member.domain;
 
 import com.example.demo.chat.domain.ChatRoom;
-import com.example.demo.chat.domain.Message;
 import com.example.demo.enums.member.MemberRole;
 import com.example.demo.portfolio.domain.Portfolio;
 import jakarta.persistence.*;

--- a/demo/src/main/java/com/example/demo/member/dto/AuthDTO.java
+++ b/demo/src/main/java/com/example/demo/member/dto/AuthDTO.java
@@ -13,7 +13,7 @@ public class AuthDTO {
     @AllArgsConstructor
     @Builder
     public static class Request {
-        @Schema(type = "string", example = "ROLE_USER")
+        @Schema(type = "string", example = "ROLE_CUSTOMER 또는 ROLE_WEDDING_PLANNER")
         private String role;
     }
 
@@ -24,7 +24,7 @@ public class AuthDTO {
     @AllArgsConstructor
     @Builder
     public static class Response {
-        @Schema(type = "string", example = "ROLE_USER")
+        @Schema(type = "string", example = "CUSTOMER 또는 WEDDING_PLANNER")
         private String role;
         @Schema(type = "string", example = "84f6cd04-9985-4da6-94b5-e79fffd88e61")
         private String UUID;

--- a/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
+++ b/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/portfolio")
 @Tag(name = "portfolio", description = "포트폴리오 API")
 public class PortfolioController {
 
@@ -23,7 +23,7 @@ public class PortfolioController {
 
     private final PortfolioSearchService portfolioSearchService;
 
-    @GetMapping("/portfolio/get/{id}")
+    @GetMapping("/shared/{id}")
     @Operation(summary = "[공통] 특정 포트폴리오 조회")
     public ResponseEntity<PortfolioDTO.Response> getPortfolioById(
             @Parameter(description = "portfolioId")
@@ -32,14 +32,14 @@ public class PortfolioController {
         return ResponseEntity.ok(portfolioResponse);
     }
 
-    @PostMapping("/weddingplanner/portfolio/create")
+    @PostMapping("/weddingplanner/create")
     @Operation(summary = "[웨딩플래너] 포트폴리오 작성")
     public ResponseEntity<PortfolioDTO.Response> createPortfolio(@RequestBody PortfolioDTO.Request portfolioRequest) {
         PortfolioDTO.Response createdPortfolio = portfolioService.createPortfolio(portfolioRequest);
         return ResponseEntity.status(201).body(createdPortfolio);
     }
 
-    @PostMapping("/weddingplanner/portfolio/update/{id}")
+    @PostMapping("/weddingplanner/update/{id}")
     @Operation(summary = "[웨딩플래너] 특정 포트폴리오 업데이트")
     public ResponseEntity<PortfolioDTO.Response> updatePortfolio(
             @Parameter(description = "portfolioId")
@@ -48,7 +48,7 @@ public class PortfolioController {
         return ResponseEntity.ok(updatedPortfolio);
     }
 
-    @PostMapping("/weddingplanner/portfolio/delete/{id}")
+    @PostMapping("/weddingplanner/delete/{id}")
     @Operation(summary = "[웨딩플래너] 특정 포트폴리오 삭제")
     public ResponseEntity<Void> deletePortfolio(
             @Parameter(description = "portfolioId")
@@ -57,21 +57,21 @@ public class PortfolioController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/portfolio/get/soft-deleted")
+    @GetMapping("/shared/soft-deleted")
     @Operation(summary = "[공통] soft-deleted가 된 포트폴리오 조회")
     public ResponseEntity<List<PortfolioDTO.Response>> getAllSoftDeleted() {
         List<PortfolioDTO.Response> softDeletedPortfolios = portfolioService.getAllSoftDeletedPortfolios();
         return ResponseEntity.ok(softDeletedPortfolios);
     }
 
-    @GetMapping("/portfolio/get")
+    @GetMapping("/shared/all")
     @Operation(summary = "[공통] soft-deleted 를 포함한 전체 포트폴리오 조회")
     public ResponseEntity<List<PortfolioDTO.Response>> getAllPortfolios() {
         List<PortfolioDTO.Response> portfolioResponses = portfolioService.getAllPortfolios();
         return ResponseEntity.ok(portfolioResponses);
     }
 
-    @GetMapping("/portfolio/search")
+    @GetMapping("/shared/search")
     @Operation(summary = "[공통] 포트폴리오 검색하여 조회")
     public ResponseEntity<List<PortfolioSearchDTO.Response>> getSearchPortfolio(
             @Parameter(description = "검색 키워드")

--- a/demo/src/main/java/com/example/demo/review/controller/ReviewCotroller.java
+++ b/demo/src/main/java/com/example/demo/review/controller/ReviewCotroller.java
@@ -13,20 +13,20 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/review")
 @Tag(name = "review", description = "리뷰 API")
 public class ReviewCotroller {
 
     private final ReviewService reviewService;
 
-    @GetMapping("/review/get")
+    @GetMapping("/shared/all")
     @Operation(summary = "[공통] 전체 리뷰 조회")
     public ResponseEntity<List<ReviewDTO.Response>> getAllReviews() {
         List<ReviewDTO.Response> reviewResponses = reviewService.getAllReviews();
         return ResponseEntity.ok(reviewResponses);
     }
 
-    @GetMapping("/review/get/{id}")
+    @GetMapping("/shared/{id}")
     @Operation(summary = "[공통] 특정 리뷰 조회")
     public ResponseEntity<ReviewDTO.Response> getReviewById(
             @Parameter(description = "reviewId")
@@ -34,21 +34,21 @@ public class ReviewCotroller {
         ReviewDTO.Response reviewResponse = reviewService.getReviewById(id);
         return ResponseEntity.ok(reviewResponse);
     }
-    @PostMapping("/weddingplanner/review/create")
+    @PostMapping("/weddingplanner/create")
     @Operation(summary = "[웨딩플래너] 리뷰 작성")
     public ResponseEntity<ReviewDTO.Response> createReviewForWeddingPlanner(@RequestBody ReviewDTO.Request reviewRequest) {
         ReviewDTO.Response createdReview = reviewService.createReviewForWeddingPlanner(reviewRequest);
         return ResponseEntity.ok(createdReview);
     }
 
-    @PostMapping("/customer/review/create")
+    @PostMapping("/customer/create")
     @Operation(summary = "[신랑신부] 리뷰 작성")
     public ResponseEntity<ReviewDTO.Response> createReviewForCustomer(@RequestBody ReviewDTO.Request reviewRequest) {
         ReviewDTO.Response createdReview = reviewService.createReviewForCustomer(reviewRequest);
         return ResponseEntity.ok(createdReview);
     }
 
-    @PostMapping("/weddingplanner/review/update/{id}")
+    @PostMapping("/weddingplanner/update/{id}")
     @Operation(summary = "[웨딩플래너] 특정 리뷰 업데이트")
     public ResponseEntity<ReviewDTO.Response> updateReviewForWeddingPlanner(
             @Parameter(description = "reviewId")
@@ -57,7 +57,7 @@ public class ReviewCotroller {
         return ResponseEntity.ok(updatedReview);
     }
 
-    @PostMapping("/customer/review/update/{id}")
+    @PostMapping("/customer/update/{id}")
     @Operation(summary = "[신랑신부] 특정 리뷰 업데이트")
     public ResponseEntity<ReviewDTO.Response> updateReviewForCustomer(
             @Parameter(description = "reviewId")
@@ -66,7 +66,7 @@ public class ReviewCotroller {
         return ResponseEntity.ok(updatedReview);
     }
 
-    @PostMapping("/weddingplanner/review/delete/{id}")
+    @PostMapping("/weddingplanner/delete/{id}")
     @Operation(summary = "[웨딩플래너] 특정 리뷰 삭제")
     public ResponseEntity<Void> deleteReviewForWeddingPlanner(
             @Parameter(description = "reviewId")
@@ -75,7 +75,7 @@ public class ReviewCotroller {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/customer/review/delete/{id}")
+    @PostMapping("/customer/delete/{id}")
     @Operation(summary = "[신랑신부] 특정 리뷰 삭제")
     public ResponseEntity<Void> deleteReview(
             @Parameter(description = "reviewId")
@@ -84,21 +84,21 @@ public class ReviewCotroller {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/review/get/soft-deleted")
+    @GetMapping("/shared/soft-deleted")
     @Operation(summary = "[공통] soft-deleted 리뷰 조회")
     public ResponseEntity<List<ReviewDTO.Response>> getAllSoftDeleted() {
         List<ReviewDTO.Response> softDeletedReviews = reviewService.getAllSoftDeletedReviews();
         return ResponseEntity.ok(softDeletedReviews);
     }
 
-    @GetMapping("/customer/review/get")
+    @GetMapping("/customer/me")
     @Operation(summary = "[신랑신부] 내 리뷰 조회")
     public ResponseEntity<List<ReviewDTO.Response>> getMyReviewsForCustomer() {
         List<ReviewDTO.Response> myReviews = reviewService.getMyReviewsForCustomer();
         return ResponseEntity.ok(myReviews);
     }
 
-    @GetMapping("/weddingplanner/review/get")
+    @GetMapping("/weddingplanner/me")
     @Operation(summary = "[웨딩플래너] 내 리뷰 조회")
     public ResponseEntity<List<ReviewDTO.Response>> getMyReviewsForWeddingplanner() {
 

--- a/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
+++ b/demo/src/main/java/com/example/demo/wishlist/controller/WishListController.java
@@ -15,13 +15,13 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/wishlist")
 @Tag(name = "wishlist", description = "wishlist API")
 public class WishListController {
 
     private final WishListService wishListService;
 
-    @GetMapping("/customer/wishlists/get")
+    @GetMapping("/customer/me")
     @Operation(summary = "[신랑신부] 위시리스트 목록 조회", description = "customer가 자신의 위시리스트 목록을 조회합니다.")
     public ResponseEntity<List<PortfolioOverviewDTO.Response>> getWishListByMember(@RequestParam(value = "page", defaultValue = "0") int page,
                                                                             @RequestParam(value = "size", defaultValue = "10") int size){
@@ -29,7 +29,7 @@ public class WishListController {
         return ResponseEntity.ok(portfolioOverviews);
     }
 
-    @PostMapping("/customer/wishlists/post/{id}")
+    @PostMapping("/customer/post/{id}")
     @Operation(summary = "[신랑신부] 위시리스트 추가", description = "customer가 자신이 원하는 포트폴리오를 위시리스트에 추가합니다.")
     public ResponseEntity<Void> addWishList(
             @Parameter(description = "portfolioId")
@@ -38,7 +38,7 @@ public class WishListController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/customer/wishlists/delete/{id}")
+    @PostMapping("/customer/delete/{id}")
     @Operation(summary = "[신랑신부] 위시리스트 삭제", description = "customer가 자신의 위시리스트에서 포트폴리오를 삭제합니다.")
     public ResponseEntity<Void> deleteWishList(
             @Parameter(description = "portfolioId")


### PR DESCRIPTION
### PR 요약
- swagger에 나타나는 controller url 통일
- url prefix에 따라 springsecurity requestmatchers 변경

### 변경 사항
- api/v1/{적용도메인}/{주체}/기타 기능사항 으로 통일하였습니다.
주체는 공통을 shared, 웨딩플래너를 weddingplanner, 신랑신부를 customer로 통일하였습니다.

- SecurityConfig requestmatchers

### 참고 사항
Spring Security URL 설정 시 구체적인 URL 패턴을 먼저 배치해야 합니다. 예를 들어 아래의 순서는 가능합니다.
`
.requestMatchers("/api/v1/auth/shared/create").permitAll()
.requestMatchers("/api/v1/*/shared/**").hasAnyRole("CUSTOMER","WEDDING_PLANNER")
`

`/api/v1/auth/shared/create` 같은 경우 위에서 먼저 걸러진 후에 나머지 `/api/v1/portfolio/shared/all` 등의 API는 아래에서 걸러져 CUSTOMER 또는 WEDDING_PLANNER의 Role을 가져야 합니다.    

하지만 아래의 순서는 가능하지 않습니다.

`.requestMatchers("/api/v1/*/shared/**").hasAnyRole("CUSTOMER","WEDDING_PLANNER")
.requestMatchers("/api/v1/auth/shared/create").permitAll()
`