### PR TITLE
feat/get top 5 portfolios based on viewCount

### DIFF
--- a/demo/src/main/java/com/example/demo/dummy/DataLoader.java
+++ b/demo/src/main/java/com/example/demo/dummy/DataLoader.java
@@ -75,6 +75,7 @@ public class DataLoader implements CommandLineRunner {
                 .weddingPhotoUrls(weddingPhotos1)
                 .radarSum(radar1)
                 .wishListCount(0)
+                .viewCount(0)
                 .build();
 
         Portfolio portfolio2 = Portfolio.builder()
@@ -92,6 +93,7 @@ public class DataLoader implements CommandLineRunner {
                 .weddingPhotoUrls(weddingPhotos2)
                 .radarSum(radar2)
                 .wishListCount(0)
+                .viewCount(0)
                 .build();
 
 

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -121,6 +121,26 @@ public class CustomUserDetailsService implements UserDetailsService {
         throw new UsernameNotFoundException("Authenticated wedding planner not found");
     }
 
+    public MemberRole getCurrentAuthenticatedMemberRole() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated() && !(authentication instanceof AnonymousAuthenticationToken)) {
+            return getMemberRole(authentication);
+        }
+        return null;
+    }
+
+    private MemberRole getMemberRole(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .findFirst()
+                .map(this::mapRole)
+                .orElse(null);
+    }
+
+    private MemberRole mapRole(String authority) {
+        return "ROLE_CUSTOMER".equals(authority) ? MemberRole.CUSTOMER : MemberRole.WEDDING_PLANNER;
+    }
+
     public MypageDTO.CustomerResponse getCustomerMyPage() {
         log.info("Getting customer my page");
         Customer customer = getCurrentAuthenticatedCustomer();

--- a/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
+++ b/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
@@ -1,5 +1,6 @@
 package com.example.demo.portfolio.controller;
 
+import com.example.demo.member.service.CustomUserDetailsService;
 import com.example.demo.portfolio.dto.PortfolioDTO;
 import com.example.demo.portfolio.dto.PortfolioSearchDTO;
 import com.example.demo.portfolio.service.PortfolioSearchService;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static com.example.demo.enums.member.MemberRole.CUSTOMER;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/portfolio")
@@ -26,11 +29,16 @@ public class PortfolioController {
 
     private final PortfolioSearchService portfolioSearchService;
 
+    private final CustomUserDetailsService customUserDetailsService;
+
     @GetMapping("/shared/{portfolioId}")
     @Operation(summary = "[공통] 특정 포트폴리오 조회")
     public ResponseEntity<PortfolioDTO.Response> getPortfolioById(
             @Parameter(description = "portfolioId")
             @PathVariable Long portfolioId) {
+        if (customUserDetailsService.getCurrentAuthenticatedMemberRole().equals(CUSTOMER)){
+            portfolioService.increaseViewCount(portfolioId);
+        }
         PortfolioDTO.Response portfolioResponse = portfolioService.getPortfolioById(portfolioId);
         log.info("Fetched portfolio with ID: {}", portfolioId);
         return ResponseEntity.ok(portfolioResponse);
@@ -99,4 +107,12 @@ public class PortfolioController {
         log.info("Searched portfolios with content: {}", content);
         return ResponseEntity.ok(searchResult);
     }
+
+    @GetMapping("/shared/top5")
+    @Operation(summary = "[공통] 조회수 상위 5개 포트폴리오 조회")
+    public ResponseEntity<List<PortfolioDTO.Response>> getTop5Portfolios() {
+        List<PortfolioDTO.Response> top5Portfolios = portfolioService.getTop5Portfolios();
+        return ResponseEntity.ok(top5Portfolios);
+    }
+
 }

--- a/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
+++ b/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
@@ -70,6 +70,8 @@ public class Portfolio extends BaseTimeEntity {
 
     private Integer wishListCount;
 
+    private Integer viewCount;
+
 
     public void increaseWishListCount() {
         if (this.wishListCount == null) {

--- a/demo/src/main/java/com/example/demo/portfolio/repository/PortfolioRepository.java
+++ b/demo/src/main/java/com/example/demo/portfolio/repository/PortfolioRepository.java
@@ -30,4 +30,14 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
 
     @Query(value = "SELECT * from Portfolio portfolio WHERE portfolio.is_deleted = true", nativeQuery = true)
     List<Portfolio> findSoftDeletedPortfolios();
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Portfolio p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
+    void increaseViewCount(@Param("id") Long id);
+
+
+    //조회수 top5
+    @Query(value = "SELECT * FROM Portfolio p ORDER BY p.view_count DESC LIMIT 5", nativeQuery = true)
+    List<Portfolio> findTop5ByViewCount();
 }

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -297,4 +297,22 @@ public class PortfolioService {
         return radarSum.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> Math.round(entry.getValue() / radarCount * 10) / 10f));
     }
+
+    @Transactional
+    public Portfolio increaseViewCount(Long portfolioId) {
+        Portfolio portfolio = portfolioRepository.findPortfolioByIdWithPessimisticLock(portfolioId)
+                .orElseThrow(() -> new RuntimeException("Portfolio not found"));
+
+        portfolioRepository.increaseViewCount(portfolioId);
+        portfolioRepository.save(portfolio);
+        portfolioSearchService.updateDocumentUsingDTO(portfolio);
+        return portfolio;
+    }
+
+    public List<PortfolioDTO.Response> getTop5Portfolios() {
+        return portfolioRepository.findTop5ByViewCount().stream()
+                .map(portfolioMapper::entityToResponse)
+                .collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
### PR 요약
view count를 기준으로 top 5에 속하는 포트폴리오 리스트 가져오기 
findByPortfolioId 메소드가 불리면서, 해당 인증 객체가 CUSTOMER인 상황에서 viewCount를 +1 시킵니다.

### 변경 사항
CustomerUserDetailsService 및 PortfolioController/Service/Repository

### 참고 사항
추후 Redis 등으로 개선할 예정입니다.