### PR TITLE
Fix/Resolve circular reference between chatroom and messages

### DIFF
--- a/demo/src/main/java/com/example/demo/chat/dto/ChatRoomDTO.java
+++ b/demo/src/main/java/com/example/demo/chat/dto/ChatRoomDTO.java
@@ -34,7 +34,7 @@ public class ChatRoomDTO {
     public static class Response {
         private Long id;
 
-        private List<Message> messages;
+        private List<MessageDTO.Response> messages;
 
         private Long customerLastReadMessageId;
 


### PR DESCRIPTION
### PR 요약
- Chatroom에 할당된 메세지 정보를 가져올 때, response에서 생기는 순환 참조 문제를 해결

### 변경 사항
- response에 messageDTO를 할당해주어 해결

### 참고 사항
