### PR TITLE
Feat/Redis

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -90,6 +90,11 @@ dependencies {
 
     // log4j2
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+
 }
 
 tasks.named('test') {

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -93,6 +93,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce.core:lettuce-core'
 
 
 }

--- a/demo/src/main/java/com/example/demo/config/RedisConfig.java
+++ b/demo/src/main/java/com/example/demo/config/RedisConfig.java
@@ -1,0 +1,46 @@
+package com.example.demo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+//    @Value("${spring.data.redis.password}")
+//    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(host);
+        redisConfiguration.setPort(port);
+//        redisConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplateRT() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+
+}

--- a/demo/src/main/java/com/example/demo/config/RedisConfig.java
+++ b/demo/src/main/java/com/example/demo/config/RedisConfig.java
@@ -21,15 +21,11 @@ public class RedisConfig {
     @Value("${spring.data.redis.host}")
     private String host;
 
-//    @Value("${spring.data.redis.password}")
-//    private String password;
-
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
         redisConfiguration.setHostName(host);
         redisConfiguration.setPort(port);
-//        redisConfiguration.setPassword(password);
         return new LettuceConnectionFactory(redisConfiguration);
     }
 

--- a/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
+++ b/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
@@ -1,0 +1,84 @@
+package com.example.demo.redis.controller;
+
+import com.example.demo.redis.service.RedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/redis")
+@RequiredArgsConstructor
+public class RedisController {
+
+    private final RedisService redisService;
+
+    @PostMapping("/set")
+    public void setValue(@RequestParam String key, @RequestParam String value) {
+        log.info("Setting value for key: {}", key);
+        redisService.setValue(key, value);
+        log.info("Value set for key: {}", key);
+    }
+
+    @PostMapping("/setWithExpiry")
+    public void setValueWithExpiry(@RequestParam String key, @RequestParam String value, @RequestParam long durationInSeconds) {
+        log.info("Setting value with expiry for key: {} for duration: {} seconds", key, durationInSeconds);
+        redisService.setValue(key, value, Duration.ofSeconds(durationInSeconds));
+        log.info("Value with expiry set for key: {}", key);
+    }
+
+    @GetMapping("/get")
+    public String getValue(@RequestParam String key) {
+        log.info("Getting value for key: {}", key);
+        String value = redisService.getValue(key);
+        log.info("Retrieved value for key: {}", key);
+        return value;
+    }
+
+    @DeleteMapping("/delete")
+    public void deleteValue(@RequestParam String key) {
+        log.info("Deleting value for key: {}", key);
+        redisService.deleteValue(key);
+        log.info("Deleted value for key: {}", key);
+    }
+
+    @PostMapping("/expire")
+    public void expireValue(@RequestParam String key, @RequestParam int timeout) {
+        log.info("Setting expire timeout for key: {} to: {} milliseconds", key, timeout);
+        redisService.expireValue(key, timeout);
+        log.info("Expire timeout set for key: {}", key);
+    }
+
+    @PostMapping("/setHash")
+    public void setHashOps(@RequestParam String key, @RequestBody Map<String, String> data) {
+        log.info("Setting hash ops for key: {} with data: {}", key, data);
+        redisService.setHashOps(key, data);
+        log.info("Hash ops set for key: {}", key);
+    }
+
+    @GetMapping("/getHash")
+    public String getHashOps(@RequestParam String key, @RequestParam String hashKey) {
+        log.info("Getting hash ops for key: {} and hashKey: {}", key, hashKey);
+        String value = redisService.getHashOps(key, hashKey);
+        log.info("Retrieved hash ops for key: {} and hashKey: {}", key, hashKey);
+        return value;
+    }
+
+    @DeleteMapping("/deleteHash")
+    public void deleteHashOps(@RequestParam String key, @RequestParam String hashKey) {
+        log.info("Deleting hash ops for key: {} and hashKey: {}", key, hashKey);
+        redisService.deleteHashOps(key, hashKey);
+        log.info("Deleted hash ops for key: {} and hashKey: {}", key, hashKey);
+    }
+
+    @GetMapping("/exists")
+    public boolean checkExistsValue(@RequestParam String key) {
+        log.info("Checking existence for key: {}", key);
+        boolean exists = redisService.checkExistsValue(redisService.getValue(key));
+        log.info("Existence check for key: {} is: {}", key, exists);
+        return exists;
+    }
+}

--- a/demo/src/main/java/com/example/demo/redis/service/RedisService.java
+++ b/demo/src/main/java/com/example/demo/redis/service/RedisService.java
@@ -1,0 +1,67 @@
+package com.example.demo.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValue(String key, String data) {
+        ValueOperations<String, Object> value = redisTemplate.opsForValue();
+        value.set(key, data);
+    }
+
+    public void setValue(String key, String data, Duration duration) {
+        ValueOperations<String, Object> value = redisTemplate.opsForValue();
+        value.set(key, data, duration);
+    }
+
+    @Transactional(readOnly = true)
+    public String getValue(String key) {
+        ValueOperations<String, Object> value = redisTemplate.opsForValue();
+        if (value.get(key) == null) {
+            return "false";
+        }
+        return (String) value.get(key);
+    }
+
+    public void deleteValue(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void expireValue(String key, int timeout) {
+        redisTemplate.expire(key, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    public void setHashOps(String key, Map<String, String> data) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.putAll(key, data);
+    }
+
+    @Transactional(readOnly = true)
+    public String getHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        return Boolean.TRUE.equals(values.hasKey(key, hashKey)) ? (String) redisTemplate.opsForHash().get(key, hashKey) : "";
+    }
+
+    public void deleteHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.delete(key, hashKey);
+    }
+
+    public boolean checkExistsValue(String value) {
+        return !value.equals("false");
+    }
+}

--- a/demo/src/main/resources/application-prod.yml
+++ b/demo/src/main/resources/application-prod.yml
@@ -19,6 +19,10 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         show_sql: true
         format_sql: true
+  data:
+    redis:
+      port: 6379
+      host: ${REDIS_HOSTNAME}
 
 springdoc:
   api-docs:

--- a/demo/src/main/resources/application.yml
+++ b/demo/src/main/resources/application.yml
@@ -32,6 +32,10 @@ spring:
     password: ${ELASTICSEARCH_PASSWORD}
     repositories:
       enabled: true
+  data:
+    redis:
+      port: 6379
+      host: localhost
 
 springdoc:
   api-docs:

--- a/demo/src/test/java/com/example/demo/redis/service/RedisServiceTest.java
+++ b/demo/src/test/java/com/example/demo/redis/service/RedisServiceTest.java
@@ -1,0 +1,171 @@
+package com.example.demo.redis.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class RedisServiceTest {
+
+    private RedisService redisService;
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        redisService = new RedisService(redisTemplate);
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+    }
+
+    @Test
+    public void testSetValue() {
+        String key = "testKey";
+        String data = "testData";
+
+        redisService.setValue(key, data);
+
+        verify(valueOperations, times(1)).set(key, data);
+    }
+
+    @Test
+    public void testSetValueWithDuration() {
+        String key = "testKey";
+        String data = "testData";
+        Duration duration = Duration.ofMinutes(5);
+
+        redisService.setValue(key, data, duration);
+
+        verify(valueOperations, times(1)).set(key, data, duration);
+    }
+
+    @Test
+    public void testGetValue() {
+        String key = "testKey";
+        String data = "testData";
+
+        when(valueOperations.get(key)).thenReturn(data);
+
+        String result = redisService.getValue(key);
+
+        assertEquals(data, result);
+    }
+
+    @Test
+    public void testGetValueReturnsFalseWhenNull() {
+        String key = "testKey";
+
+        when(valueOperations.get(key)).thenReturn(null);
+
+        String result = redisService.getValue(key);
+
+        assertEquals("false", result);
+    }
+
+    @Test
+    public void testDeleteValue() {
+        String key = "testKey";
+
+        redisService.deleteValue(key);
+
+        verify(redisTemplate, times(1)).delete(key);
+    }
+
+    @Test
+    public void testExpireValue() {
+        String key = "testKey";
+        int timeout = 5000;
+
+        redisService.expireValue(key, timeout);
+
+        verify(redisTemplate, times(1)).expire(key, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testSetHashOps() {
+        String key = "testKey";
+        Map<String, String> data = new HashMap<>();
+        data.put("hashKey1", "value1");
+        data.put("hashKey2", "value2");
+
+        redisService.setHashOps(key, data);
+
+        verify(hashOperations, times(1)).putAll(key, data);
+    }
+
+    @Test
+    public void testGetHashOps() {
+        String key = "testKey";
+        String hashKey = "hashKey";
+        String data = "testData";
+
+        when(hashOperations.hasKey(key, hashKey)).thenReturn(true);
+        when(hashOperations.get(key, hashKey)).thenReturn(data);
+
+        String result = redisService.getHashOps(key, hashKey);
+
+        assertEquals(data, result);
+    }
+
+    @Test
+    public void testGetHashOpsReturnsEmptyStringWhenNotFound() {
+        String key = "testKey";
+        String hashKey = "hashKey";
+
+        when(hashOperations.hasKey(key, hashKey)).thenReturn(false);
+
+        String result = redisService.getHashOps(key, hashKey);
+
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testDeleteHashOps() {
+        String key = "testKey";
+        String hashKey = "hashKey";
+
+        redisService.deleteHashOps(key, hashKey);
+
+        verify(hashOperations, times(1)).delete(key, hashKey);
+    }
+
+    @Test
+    public void testCheckExistsValue() {
+        String value = "testValue";
+
+        boolean result = redisService.checkExistsValue(value);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testCheckExistsValueReturnsFalseForFalseString() {
+        String value = "false";
+
+        boolean result = redisService.checkExistsValue(value);
+
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
### PR 요약
- Redis 도입(Lettuce)

### 변경 사항
- AWS ElasticCache 생성 후 EB와 연동
- 아래와 같은 기능 제공
  - setValue(key, data)
  - setValue(key, data, duration)
  - getValue(key)
  - deleteValue(key)
  - expireValue(key, timeout)
  - setHashOps(key, mapData)
  - getHashOps(key, hashKey)
  - checkExistsValue(value)
- 기능들에 대한 간단한 Test 작성
### 참고 사항
Service 단에서 아래 필드 선언하고 사용
`private final RedisTemplate<String, Object> redisTemplateRT;`