### PR TITLE
fix/update s3 prefix url policy and change response format

### DIFF
--- a/demo/src/main/java/com/example/demo/config/S3Uploader.java
+++ b/demo/src/main/java/com/example/demo/config/S3Uploader.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Component
 @Profile("!test")
@@ -32,14 +31,15 @@ public class S3Uploader {
     private final int PRESIGNED_URL_EXPIRATION = 60 * 1000 * 10; // 10분
 
 
-    public String getPresignedUrl(String fileName) {
+    private String getPresignedUrl(String fileName) {
         return generatePresignedUrl(fileName).toString();
     }
 
 
     // Upload file to S3 using presigned url
     private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String fileName) {
-        return new GeneratePresignedUrlRequest(bucket, cloudfrontPath + "/" + fileName)
+        System.out.println("fileName: " + fileName);
+        return new GeneratePresignedUrlRequest(bucket, fileName)
                 .withMethod(HttpMethod.PUT)
                 .withExpiration(setExpiration());
     }
@@ -58,13 +58,15 @@ public class S3Uploader {
         return expiration;
     }
 
-    public String getUniqueFilename(String fileName) {
-        return UUID.randomUUID().toString();
+    public String makeFileNameWithOutCloudFront(String type, Long id, String fileName) {
+        return type + "/" + id +"/" + UUID.randomUUID() + "." + getFileExtension(fileName);
     }
 
-    //get file from cloudfront not using presigned url
-    private String getCloudfrontFilePath(String fileName) {
-        return cloudfrontPath + fileName;
+    public static String getFileExtension(String fileName) throws RuntimeException{
+        if (fileName == null || fileName.lastIndexOf('.') == -1) {
+            throw new RuntimeException("파일 확장자가 없습니다.");
+        }
+        return fileName.substring(fileName.lastIndexOf('.') + 1);
     }
 
     public void deleteFile(String fileName){
@@ -72,16 +74,8 @@ public class S3Uploader {
             return;
         }
         if (checkFileExists(fileName)){
-            s3Config.amazonS3().deleteObject(new DeleteObjectRequest(bucket, cloudfrontPath+"/"+fileName));
+            s3Config.amazonS3().deleteObject(new DeleteObjectRequest(bucket, fileName));
         }
-    }
-
-    public void deleteFiles(List<String> fileNames) {
-        if (fileNames == null || fileNames.isEmpty()) {
-            return;
-        }
-
-        fileNames.forEach(this::deleteFile);
     }
 
 
@@ -92,23 +86,18 @@ public class S3Uploader {
     public List<String> uploadFileList(List<String> fileNameList){
         List<String> presignedUrlList = new ArrayList<>();
         for (String fileName : fileNameList) {
-            String uniqueFileName = getUniqueFilename(fileName);
-            presignedUrlList.add(getPresignedUrl(uniqueFileName));
+            presignedUrlList.add(getPresignedUrl(fileName));
         }
         return presignedUrlList;
     }
 
-    public String getImageUrl(String uniqueFileName){
-        return getCloudfrontFilePath(uniqueFileName);
-    }
-
-    public List<String> getImageUrls(List<String> imageUrls) {
-        return imageUrls.stream()
-                .map(this::getImageUrl)
-                .collect(Collectors.toList());
-    }
-
-    public boolean checkFileExists(String fileName) {
-        return s3Config.amazonS3().doesObjectExist(bucket, cloudfrontPath + "/" + fileName);
+    private boolean checkFileExists(String fileName) {
+        // cloudfrontUrl 부분을 앞에서부터 제거
+        String cleanedFileName = fileName;
+        if (fileName.startsWith(cloudfrontPath)) {
+            cleanedFileName = fileName.substring(cloudfrontPath.length());
+        }
+        return s3Config.amazonS3().doesObjectExist(bucket, cleanedFileName);
     }
 }
+

--- a/demo/src/main/java/com/example/demo/config/S3Uploader.java
+++ b/demo/src/main/java/com/example/demo/config/S3Uploader.java
@@ -29,16 +29,11 @@ public class S3Uploader {
     private String cloudfrontPath;
 
     private final int PRESIGNED_URL_EXPIRATION = 60 * 1000 * 10; // 10분
-
-
-    private String getPresignedUrl(String fileName) {
-        return generatePresignedUrl(fileName).toString();
-    }
+    
 
 
     // Upload file to S3 using presigned url
     private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String fileName) {
-        System.out.println("fileName: " + fileName);
         return new GeneratePresignedUrlRequest(bucket, fileName)
                 .withMethod(HttpMethod.PUT)
                 .withExpiration(setExpiration());
@@ -58,7 +53,7 @@ public class S3Uploader {
         return expiration;
     }
 
-    public String makeFileNameWithOutCloudFront(String type, Long id, String fileName) {
+    public String makeUniqueFileName(String type, Long id, String fileName) {
         return type + "/" + id +"/" + UUID.randomUUID() + "." + getFileExtension(fileName);
     }
 
@@ -79,14 +74,14 @@ public class S3Uploader {
     }
 
 
-    public String uploadFile(String fileName){
-        return getPresignedUrl(fileName);
+    public String getPresignedUrl(String fileName){
+        return generatePresignedUrl(fileName).toString();
     }
 
-    public List<String> uploadFileList(List<String> fileNameList){
+    public List<String> getPresignedUrls(List<String> fileNameList){
         List<String> presignedUrlList = new ArrayList<>();
         for (String fileName : fileNameList) {
-            presignedUrlList.add(getPresignedUrl(fileName));
+            presignedUrlList.add(generatePresignedUrl(fileName).toString());
         }
         return presignedUrlList;
     }

--- a/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
+++ b/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
@@ -79,7 +79,7 @@ public class PortfolioController {
             @PathVariable Long portfolioId) {
         portfolioService.deletePortfolio(portfolioId);
         log.info("Deleted portfolio with ID: {}", portfolioId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/shared/soft-deleted")

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -91,7 +91,6 @@ public class PortfolioService {
         String profileImagePresignedUrl = s3Uploader.getPresignedUrl(portfolioRequest.getProfileImageUrl());
         List<String> weddingPhotoPresignedUrlList = s3Uploader.getPresignedUrls(portfolioRequest.getWeddingPhotoUrls());
 
-        //save portfolio
         Portfolio savedPortfolio = portfolioRepository.save(portfolio);
         PortfolioDTO.Response response = portfolioMapper.entityToResponse(savedPortfolio);
 
@@ -123,7 +122,6 @@ public class PortfolioService {
             List<String> existingWeddingPhotoUrls = existingPortfolio.getWeddingPhotoUrls();
             List<String> newWeddingPhotoUrls = portfolioRequest.getWeddingPhotoUrls();
 
-            System.out.println("existingWeddingPhotoUrls: "+existingWeddingPhotoUrls);
             //삭제한 이미지 s3에서 삭제
             Iterator<String> iterator = existingWeddingPhotoUrls.iterator();
             while (iterator.hasNext()) {
@@ -153,7 +151,6 @@ public class PortfolioService {
         if (!weddingPhotosPresignedUrlList.isEmpty()) {
             response.setPresignedWeddingPhotoUrls(weddingPhotosPresignedUrlList);
         }
-        System.out.println("weddingPhotosPresignedUrlList 개수"+weddingPhotosPresignedUrlList.size());
         portfolioSearchService.updateDocumentUsingDTO(savedPortfolio);
         return response;
     }

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -17,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -46,7 +48,6 @@ public class PortfolioService {
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new RuntimeException("Portfolio not found"));
 
-        updatePortfolioImageUrls(portfolio);
         PortfolioDTO.Response portfolioResponse = portfolioMapper.entityToResponse(portfolio);
 
         portfolioResponse.setWeddingPlannerPortfolioResponse(
@@ -69,37 +70,91 @@ public class PortfolioService {
 
     @Transactional
     public PortfolioDTO.Response createPortfolio(PortfolioDTO.Request portfolioRequest) {
-        log.info("Starting createPortfolio method with data: {}", portfolioRequest);
+
         WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
 
-        preparePortfolioImages(portfolioRequest);
+        //일단 id를 가져오기 위한 save
+        Portfolio portfolio = portfolioRepository.save(portfolioMapper.requestToEntity(portfolioRequest));
 
-        Portfolio savedPortfolio = portfolioRepository.save(portfolioMapper.requestToEntity(portfolioRequest));
-        weddingPlanner.setPortfolio(savedPortfolio);
+        //weddingplanner 할당
+        portfolio.setWeddingPlanner(weddingPlanner);
 
-        PortfolioDTO.Response response = buildPortfolioResponse(savedPortfolio);
+        //portfolio/{id}/uuid 형식으로 이미지명 생성
+        portfolio.setProfileImageUrl(s3Uploader.makeFileNameWithOutCloudFront("portfolio", portfolio.getId(), portfolioRequest.getProfileImageUrl()));
+        portfolio.setWeddingPhotoUrls(
+                portfolioRequest.getWeddingPhotoUrls().stream()
+                        .map(url -> s3Uploader.makeFileNameWithOutCloudFront("portfolio", portfolio.getId(), url))
+                        .collect(Collectors.toList())
+        );
+
+        //presignedUrl 각각 가져오기
+        String profileImagePresignedUrl = s3Uploader.uploadFile(portfolioRequest.getProfileImageUrl());
+        List<String> weddingPhotoPresignedUrlList = s3Uploader.uploadFileList(portfolioRequest.getWeddingPhotoUrls());
+
+        //save portfolio
+        Portfolio savedPortfolio = portfolioRepository.save(portfolio);
+        PortfolioDTO.Response response = portfolioMapper.entityToResponse(savedPortfolio);
+
+        response.setPresignedProfileImageUrl(profileImagePresignedUrl);
+        response.setPresignedWeddingPhotoUrls(weddingPhotoPresignedUrlList);
+
         portfolioSearchService.indexDocumentUsingDTO(savedPortfolio);
-
-        log.info("Created new portfolio with data: {}", portfolioRequest);
         return response;
     }
 
     @Transactional
     public PortfolioDTO.Response updatePortfolio(Long portfolioId, PortfolioDTO.Request portfolioRequest) {
         log.info("Starting updatePortfolio method for portfolio ID: {} with data: {}", portfolioId, portfolioRequest);
-        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
         Portfolio existingPortfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new RuntimeException("Portfolio not found"));
 
-        updatePortfolioImages(portfolioRequest, existingPortfolio);
-        Portfolio updatedPortfolio = portfolioMapper.updateFromRequest(portfolioRequest, existingPortfolio);
-        portfolioRepository.save(updatedPortfolio);
-        weddingPlanner.setPortfolio(updatedPortfolio);
 
-        PortfolioDTO.Response response = buildPortfolioResponse(updatedPortfolio);
-        portfolioSearchService.updateDocumentUsingDTO(updatedPortfolio);
+        String profileImagePresigendUrl = "";
+        if(portfolioRequest.getProfileImageUrl() != null && !portfolioRequest.getProfileImageUrl().equals(existingPortfolio.getProfileImageUrl())) {
+            //Delete existing image from s3 and upload new image
+            s3Uploader.deleteFile(existingPortfolio.getProfileImageUrl());
+            existingPortfolio.setProfileImageUrl(s3Uploader.makeFileNameWithOutCloudFront("portfolio", portfolioId, portfolioRequest.getProfileImageUrl()));
+            profileImagePresigendUrl = s3Uploader.uploadFile(existingPortfolio.getProfileImageUrl());
+        }
 
-        log.info("Updated portfolio with ID: {} with data: {}", portfolioId, portfolioRequest);
+        List<String> weddingPhotosPresignedUrlList = new ArrayList<>();
+        if (portfolioRequest.getWeddingPhotoUrls() != null) {
+
+            List<String> existingWeddingPhotoUrls = existingPortfolio.getWeddingPhotoUrls();
+            List<String> newWeddingPhotoUrls = portfolioRequest.getWeddingPhotoUrls();
+
+            System.out.println("existingWeddingPhotoUrls: "+existingWeddingPhotoUrls);
+            //삭제한 이미지 s3에서 삭제
+            Iterator<String> iterator = existingWeddingPhotoUrls.iterator();
+            while (iterator.hasNext()) {
+                String existingUrl = iterator.next();
+                if (!newWeddingPhotoUrls.contains(existingUrl)) {
+                    s3Uploader.deleteFile(existingUrl);
+                    iterator.remove();
+                }
+            }
+
+            //새로 추가해야 하는 이미지 s3에 업로드
+            newWeddingPhotoUrls.forEach(newUrl -> {
+                if (!existingWeddingPhotoUrls.contains(newUrl)) {
+                    String newUniqueFilename = s3Uploader.makeFileNameWithOutCloudFront("portfolio", portfolioId, newUrl);
+                    existingWeddingPhotoUrls.add(newUniqueFilename);
+                    weddingPhotosPresignedUrlList.add(s3Uploader.uploadFile(newUniqueFilename));
+                }
+            });
+        }
+
+        Portfolio savedPortfolio = portfolioRepository.save(existingPortfolio);
+        PortfolioDTO.Response response = portfolioMapper.entityToResponse(savedPortfolio);
+
+        if (profileImagePresigendUrl != null) {
+            response.setPresignedProfileImageUrl(profileImagePresigendUrl);
+        }
+        if (!weddingPhotosPresignedUrlList.isEmpty()) {
+            response.setPresignedWeddingPhotoUrls(weddingPhotosPresignedUrlList);
+        }
+        System.out.println("weddingPhotosPresignedUrlList 개수"+weddingPhotosPresignedUrlList.size());
+        portfolioSearchService.updateDocumentUsingDTO(savedPortfolio);
         return response;
     }
 
@@ -152,7 +207,8 @@ public class PortfolioService {
     @Transactional
     public Portfolio reflectNewReview(ReviewDTO.Request reviewRequest) {
         log.info("Starting reflectNewReview method for review with portfolio ID: {}", reviewRequest.getPortfolioId());
-        Portfolio portfolio = getPortfolioWithLock(reviewRequest.getPortfolioId());
+        Portfolio portfolio = portfolioRepository.findById(reviewRequest.getPortfolioId())
+                .orElseThrow(() -> new RuntimeException("Portfolio not found"));
 
         updatePortfolioWithNewReview(portfolio, reviewRequest);
         portfolioRepository.save(portfolio);
@@ -181,35 +237,6 @@ public class PortfolioService {
                 .orElseThrow(() -> new RuntimeException("Portfolio not found"));
     }
 
-    private void updatePortfolioImageUrls(Portfolio portfolio) {
-        String cloudFrontImageUrl = s3Uploader.getImageUrl(portfolio.getProfileImageUrl());
-        portfolio.setProfileImageUrl(cloudFrontImageUrl);
-    }
-
-    private void preparePortfolioImages(PortfolioDTO.Request portfolioRequest) {
-        portfolioRequest.setProfileImageUrl(s3Uploader.getUniqueFilename(portfolioRequest.getProfileImageUrl()));
-        portfolioRequest.setWeddingPhotoUrls(portfolioRequest.getWeddingPhotoUrls().stream()
-                .map(s3Uploader::getUniqueFilename)
-                .collect(Collectors.toList()));
-
-        s3Uploader.uploadFile(portfolioRequest.getProfileImageUrl());
-        s3Uploader.uploadFileList(portfolioRequest.getWeddingPhotoUrls());
-    }
-
-    private void updatePortfolioImages(PortfolioDTO.Request portfolioRequest, Portfolio existingPortfolio) {
-        if (portfolioRequest.getProfileImageUrl() != null) {
-            s3Uploader.deleteFile(existingPortfolio.getProfileImageUrl());
-            existingPortfolio.setProfileImageUrl(s3Uploader.getUniqueFilename(portfolioRequest.getProfileImageUrl()));
-            s3Uploader.uploadFile(portfolioRequest.getProfileImageUrl());
-        }
-        if (portfolioRequest.getWeddingPhotoUrls() != null) {
-            existingPortfolio.getWeddingPhotoUrls().forEach(s3Uploader::deleteFile);
-            existingPortfolio.setWeddingPhotoUrls(portfolioRequest.getWeddingPhotoUrls().stream()
-                    .map(s3Uploader::getUniqueFilename)
-                    .collect(Collectors.toList()));
-            s3Uploader.uploadFileList(portfolioRequest.getWeddingPhotoUrls());
-        }
-    }
 
     private void deletePortfolioImages(Portfolio portfolio) {
         String profileImageUrl = portfolio.getProfileImageUrl();
@@ -247,15 +274,6 @@ public class PortfolioService {
         portfolio.accumulateRatingSum(reviewRequest.getRating());
         portfolio.accumulateEstimate(reviewRequest.getEstimate());
         portfolio.accumulateRadarSum(reviewRequest.getRadar());
-    }
-
-    private PortfolioDTO.Response buildPortfolioResponse(Portfolio portfolio) {
-        PortfolioDTO.Response response = portfolioMapper.entityToResponse(portfolio);
-        response.setPresignedProfileImageUrl(s3Uploader.getImageUrl(portfolio.getProfileImageUrl()));
-        response.setPresignedWeddingPhotoUrls(portfolio.getWeddingPhotoUrls().stream()
-                .map(s3Uploader::getImageUrl)
-                .collect(Collectors.toList()));
-        return response;
     }
 
     private ReviewDTO.Response mapToReviewResponse(Review review) {
@@ -314,5 +332,4 @@ public class PortfolioService {
                 .map(portfolioMapper::entityToResponse)
                 .collect(Collectors.toList());
     }
-
 }

--- a/demo/src/main/java/com/example/demo/review/controller/ReviewController.java
+++ b/demo/src/main/java/com/example/demo/review/controller/ReviewController.java
@@ -82,7 +82,7 @@ public class ReviewController {
             @PathVariable Long reviewId) {
         reviewService.deleteReviewForWeddingPlanner(reviewId);
         log.info("Deleted review for wedding planner with ID: {}", reviewId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/customer/delete/{reviewId}")

--- a/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
+++ b/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
@@ -1,7 +1,6 @@
 package com.example.demo.review.dto;
 
 import com.example.demo.enums.review.RadarKey;
-import com.example.demo.portfolio.dto.PortfolioReviewDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 

--- a/demo/src/main/java/com/example/demo/review/service/ReviewService.java
+++ b/demo/src/main/java/com/example/demo/review/service/ReviewService.java
@@ -60,11 +60,11 @@ public class ReviewService {
         //review/{id}/uuid 형식으로 이미지명 생성
         review.setWeddingPhotoUrls(
                 reviewRequest.getWeddingPhotoUrls().stream()
-                        .map(url -> s3Uploader.makeFileNameWithOutCloudFront("review", review.getId(), url))
+                        .map(url -> s3Uploader.makeUniqueFileName("review", review.getId(), url))
                         .collect(Collectors.toList())
         );
 
-        List<String> presignedUrlList = s3Uploader.uploadFileList(reviewRequest.getWeddingPhotoUrls());
+        List<String> presignedUrlList = s3Uploader.getPresignedUrls(reviewRequest.getWeddingPhotoUrls());
 
         Portfolio portfolio = portfolioService.reflectNewReview(reviewRequest);
         review.setPortfolio(portfolio);
@@ -91,11 +91,11 @@ public class ReviewService {
         //review/{id}/uuid 형식으로 이미지명 생성
         review.setWeddingPhotoUrls(
                 reviewRequest.getWeddingPhotoUrls().stream()
-                        .map(url -> s3Uploader.makeFileNameWithOutCloudFront("review", review.getId(), url))
+                        .map(url -> s3Uploader.makeUniqueFileName("review", review.getId(), url))
                         .collect(Collectors.toList())
         );
 
-        List<String> presignedUrlList = s3Uploader.uploadFileList(reviewRequest.getWeddingPhotoUrls());
+        List<String> presignedUrlList = s3Uploader.getPresignedUrls(reviewRequest.getWeddingPhotoUrls());
 
         Portfolio portfolio = portfolioService.reflectNewReview(reviewRequest);
         review.setPortfolio(portfolio);
@@ -140,9 +140,9 @@ public class ReviewService {
             //새로 추가해야 하는 이미지 s3에 업로드
             newWeddingPhotoUrls.forEach(newUrl -> {
                 if (!existingWeddingPhotoUrls.contains(newUrl)) {
-                    String newUniqueFilename = s3Uploader.makeFileNameWithOutCloudFront("review", reviewId, newUrl);
+                    String newUniqueFilename = s3Uploader.makeUniqueFileName("review", reviewId, newUrl);
                     existingWeddingPhotoUrls.add(newUniqueFilename);
-                    weddingPhotosPresignedUrlList.add(s3Uploader.uploadFile(newUrl));
+                    weddingPhotosPresignedUrlList.add(s3Uploader.getPresignedUrl(newUrl));
                 }
             });
         }
@@ -190,9 +190,9 @@ public class ReviewService {
             //새로 추가해야 하는 이미지 s3에 업로드
             newWeddingPhotoUrls.forEach(newUrl -> {
                 if (!existingWeddingPhotoUrls.contains(newUrl)) {
-                    String newUniqueFilename = s3Uploader.makeFileNameWithOutCloudFront("review", reviewId, newUrl);
+                    String newUniqueFilename = s3Uploader.makeUniqueFileName("review", reviewId, newUrl);
                     existingWeddingPhotoUrls.add(newUniqueFilename);
-                    weddingPhotosPresignedUrlList.add(s3Uploader.uploadFile(newUrl));
+                    weddingPhotosPresignedUrlList.add(s3Uploader.getPresignedUrl(newUrl));
                 }
             });
         }


### PR DESCRIPTION
### PR 요약
s3 prefix url 정책을 변경 및 response 형태 변경

### 변경 사항
portfolio와 review를 올리고/수정하고/삭제하는 과정에서 S3의 사용을 변경하였습니다.
기존에 test/uuid 형태로 이미지가 들어갔다면, portfolio/{id}/uuid, review/{id}/uuid 형태의 prefix로 변경하였습니다.

### 참고 사항
포트폴리오와 리뷰는 RDB에서 soft-delete 정책을 따르지만, S3에서의 이미지 delete는 바로 s3 버킷에서 삭제됩니다.


<img width="551" alt="image" src="https://github.com/user-attachments/assets/8254502f-96f5-4ad2-85b1-96ccff350e96">
