### PR TITLE
fix/replace @Query with spring Data JPA method query for fetching top portfolios

### DIFF
--- a/demo/src/main/java/com/example/demo/portfolio/repository/PortfolioRepository.java
+++ b/demo/src/main/java/com/example/demo/portfolio/repository/PortfolioRepository.java
@@ -36,8 +36,5 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     @Query("UPDATE Portfolio p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
     void increaseViewCount(@Param("id") Long id);
 
-
-    //조회수 top5
-    @Query(value = "SELECT * FROM Portfolio p ORDER BY p.view_count DESC LIMIT 5", nativeQuery = true)
-    List<Portfolio> findTop5ByViewCount();
+    List<Portfolio> findTop3ByOrderByViewCountDesc();
 }

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -325,8 +325,10 @@ public class PortfolioService {
     }
 
     public List<PortfolioDTO.Response> getTop5Portfolios() {
-        return portfolioRepository.findTop5ByViewCount().stream()
+
+        return portfolioRepository.findTop3ByOrderByViewCountDesc().stream()
                 .map(portfolioMapper::entityToResponse)
                 .collect(Collectors.toList());
     }
 }
+


### PR DESCRIPTION
### PR 요약
기존에 @Query 로 구성되어 있던 repository 코드를 dataJPA로  변경

### 변경 사항

### 참고 사항
`GET /api/v1/portfolio/shared/top5` 오류 해결