### PR TITLE
feat/weddingplanner get his/her portfolio

### DIFF
--- a/demo/src/main/java/com/example/demo/dummy/DataLoader.java
+++ b/demo/src/main/java/com/example/demo/dummy/DataLoader.java
@@ -15,6 +15,7 @@ import com.example.demo.wishlist.repository.WishListRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -52,6 +53,18 @@ public class DataLoader implements CommandLineRunner {
                 "portfolio/3/6c30499a-f568-416c-8bf9-4e62a20c7cee.jpeg");
         List<String> weddingPhotos2 = Arrays.asList("wedding2_1.jpg", "wedding2_2.jpg");
 
+        WeddingPlanner planner1 = WeddingPlanner.builder()
+                .name("Alice")
+                .UUID("b1b3825f-304f-4bce-b3b7-91b70fe79cb7")
+                .role(WEDDING_PLANNER)
+                .build();
+
+        WeddingPlanner planner2 = WeddingPlanner.builder()
+                .name("Bob")
+                .UUID("c14h814f-33gf-4b4e-z5z7-31b70fe74cb8")
+                .role(WEDDING_PLANNER)
+                .build();
+
         Map<RadarKey, Float> radar1 = new HashMap<>();
         radar1.put(RadarKey.COMMUNICATION, 4.5f);
         radar1.put(RadarKey.BUDGET_COMPLIANCE, 3.8f);
@@ -79,6 +92,7 @@ public class DataLoader implements CommandLineRunner {
                 .minEstimate(100)
                 .services(services1)
                 .weddingPhotoUrls(weddingPhotos1)
+                .weddingPlanner(planner1)
                 .radarSum(radar1)
                 .wishListCount(0)
                 .viewCount(0)
@@ -97,6 +111,7 @@ public class DataLoader implements CommandLineRunner {
                 .minEstimate(200)
                 .services(services2)
                 .weddingPhotoUrls(weddingPhotos2)
+                .weddingPlanner(planner2)
                 .radarSum(radar2)
                 .wishListCount(0)
                 .viewCount(0)
@@ -167,28 +182,14 @@ public class DataLoader implements CommandLineRunner {
                 .role(CUSTOMER)
                 .build();
 
-        portfolioRepository.save(portfolio1);
-        portfolioRepository.save(portfolio2);
-
-        WeddingPlanner planner1 = WeddingPlanner.builder()
-                .name("Alice")
-                .UUID("b1b3825f-304f-4bce-b3b7-91b70fe79cb7")
-                .portfolio(portfolio1)
-                .role(WEDDING_PLANNER)
-                .build();
-
-        WeddingPlanner planner2 = WeddingPlanner.builder()
-                .name("Bob")
-                .UUID("c14h814f-33gf-4b4e-z5z7-31b70fe74cb8")
-                .portfolio(portfolio2)
-                .role(WEDDING_PLANNER)
-                .build();
-
         customerRepository.save(customer1);
         customerRepository.save(customer2);
 
         weddingPlannerRepository.save(planner1);
         weddingPlannerRepository.save(planner2);
+
+        portfolioRepository.save(portfolio1);
+        portfolioRepository.save(portfolio2);
 
         reviewRepository.save(review1);
         reviewRepository.save(review2);

--- a/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
+++ b/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
@@ -40,10 +40,8 @@ public class WeddingPlanner {
     @Column
     private String profileImageUrl;
 
-    //포트폴리오 1:1
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "weddingplanner_id")
-    private Portfolio portfolio;
+    @OneToOne(mappedBy = "weddingPlanner", fetch = FetchType.LAZY)
+    private Portfolio portfolio; //포트폴리오 먼저 저장하고 웨딩플래너 저장
 
     //매칭 1:N
     @OneToMany

--- a/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
+++ b/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
@@ -115,4 +115,10 @@ public class PortfolioController {
         return ResponseEntity.ok(top5Portfolios);
     }
 
+    @GetMapping("/weddingplanner/me")
+    @Operation(summary = "[웨딩플래너] 내 포트폴리오 조회")
+    public ResponseEntity<PortfolioDTO.Response> getMyPortfolio() {
+        PortfolioDTO.Response myPortfolio = portfolioService.getMyPortfolio();
+        return ResponseEntity.ok(myPortfolio);
+    }
 }

--- a/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
+++ b/demo/src/main/java/com/example/demo/portfolio/domain/Portfolio.java
@@ -41,6 +41,7 @@ public class Portfolio extends BaseTimeEntity {
     private String description;
 
     @OneToOne
+    @JoinColumn(name = "weddingplanner_id")
     private WeddingPlanner weddingPlanner;
 
     @ElementCollection(fetch = FetchType.LAZY)

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -335,5 +335,15 @@ public class PortfolioService {
                 .map(portfolioMapper::entityToResponse)
                 .collect(Collectors.toList());
     }
+
+    public PortfolioDTO.Response getMyPortfolio() {
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
+        Portfolio portfolio = weddingPlanner.getPortfolio();
+        if (portfolio == null) {
+            throw new RuntimeException("Portfolio not found");
+        }
+        PortfolioDTO.Response portfolioResponse = portfolioMapper.entityToResponse(portfolio);
+        return portfolioResponse;
+    }
 }
 


### PR DESCRIPTION
### PR 요약
- 웨딩플래너가 자신의 포트폴리오를 가져오는 controller 생성
- 양방향 매핑 Null 오류 수정

### 변경 사항
웨딩플래너 : 포트폴리오는 1 : 1 양방향 매핑입니다. 이 때 아래의 규칙을 적용해야 하여 DataLoader를 수정하여 Null 오류를 피하였습니다.

- 규칙 : 연관관계의 주인
연관관계의 주인만이 DB 연관관계와 매핑되고 외래 키를 관리할 수 있다. 반면에 주인이 아닌 쪽은 읽기만 할 수 있다.

- 저장
    - Weddingplanner와 Portfolio가 있다.( 연관관계 주인 : Weddingplanner )
    - 이 때 Weddingplanner1 저장 → Weddingplanner1 안에 Portfolio1 넣고 → Weddingplanner1 저장

### 참고 사항
DataLoader를 확인해주세요.
그 외 양방향 매핑된 다른 Entity들도 저장 순서를 확인해야 합니다.