### PR TITLE
Feat/Enter Chatroom

### DIFF
--- a/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
@@ -38,6 +38,14 @@ public class ChatRoomController {
         return ResponseEntity.status(201).body(createdChatRoom);
     }
 
+    @PostMapping("/customer/{chatRoomId}")
+    @Operation(summary = "[신랑신부] 채팅방 아이디로 채팅방 입장")
+    public ResponseEntity<ChatRoomDTO.Response> getChatRoomByIdForCustomer(@PathVariable Long chatRoomId) {
+        ChatRoomDTO.Response chatRoomByChatRoomId = chatRoomService.getMessagesByChatRoomId(chatRoomId);
+        log.info("Entered chat room for customer with chat room ID: {}", chatRoomId);
+        return ResponseEntity.status(200).body(chatRoomByChatRoomId);
+    }
+
     @PostMapping("/weddingplanner/{chatRoomId}")
     @Operation(summary = "[웨딩플래너] 채팅방 아이디로 채팅방 입장")
     public ResponseEntity<ChatRoomDTO.Response> getChatRoomByIdForWeddingPlanner(@PathVariable Long chatRoomId) {

--- a/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
@@ -38,7 +38,7 @@ public class ChatRoomController {
         return ResponseEntity.status(201).body(createdChatRoom);
     }
 
-    @PostMapping("/customer/{chatRoomId}")
+    @PostMapping("/customer/enter/{chatRoomId}")
     @Operation(summary = "[신랑신부] 채팅방 아이디로 채팅방 입장")
     public ResponseEntity<ChatRoomDTO.Response> getChatRoomByIdForCustomer(@PathVariable Long chatRoomId) {
         ChatRoomDTO.Response chatRoomByChatRoomId = chatRoomService.getMessagesByChatRoomIdForCustomer(chatRoomId);
@@ -46,7 +46,7 @@ public class ChatRoomController {
         return ResponseEntity.status(200).body(chatRoomByChatRoomId);
     }
 
-    @PostMapping("/weddingplanner/{chatRoomId}")
+    @PostMapping("/weddingplanner/enter/{chatRoomId}")
     @Operation(summary = "[웨딩플래너] 채팅방 아이디로 채팅방 입장")
     public ResponseEntity<ChatRoomDTO.Response> getChatRoomByIdForWeddingPlanner(@PathVariable Long chatRoomId) {
         ChatRoomDTO.Response chatRoomByChatRoomId = chatRoomService.getMessagesByChatRoomIdForWeddingPlanner(chatRoomId);

--- a/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
@@ -41,7 +41,7 @@ public class ChatRoomController {
     @PostMapping("/customer/{chatRoomId}")
     @Operation(summary = "[신랑신부] 채팅방 아이디로 채팅방 입장")
     public ResponseEntity<ChatRoomDTO.Response> getChatRoomByIdForCustomer(@PathVariable Long chatRoomId) {
-        ChatRoomDTO.Response chatRoomByChatRoomId = chatRoomService.getMessagesByChatRoomId(chatRoomId);
+        ChatRoomDTO.Response chatRoomByChatRoomId = chatRoomService.getMessagesByChatRoomIdForCustomer(chatRoomId);
         log.info("Entered chat room for customer with chat room ID: {}", chatRoomId);
         return ResponseEntity.status(200).body(chatRoomByChatRoomId);
     }
@@ -49,7 +49,7 @@ public class ChatRoomController {
     @PostMapping("/weddingplanner/{chatRoomId}")
     @Operation(summary = "[웨딩플래너] 채팅방 아이디로 채팅방 입장")
     public ResponseEntity<ChatRoomDTO.Response> getChatRoomByIdForWeddingPlanner(@PathVariable Long chatRoomId) {
-        ChatRoomDTO.Response chatRoomByChatRoomId = chatRoomService.getMessagesByChatRoomId(chatRoomId);
+        ChatRoomDTO.Response chatRoomByChatRoomId = chatRoomService.getMessagesByChatRoomIdForWeddingPlanner(chatRoomId);
         log.info("Entered chat room for wedding planner with chat room ID: {}", chatRoomId);
         return ResponseEntity.status(200).body(chatRoomByChatRoomId);
     }

--- a/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
@@ -20,57 +20,55 @@ public class MessageController {
     private final MessageService messageService;
     private final ChatRoomService chatRoomService;
 
-    @MessageMapping(value = "/shared/connect")
-    @Operation(summary = "채팅방 연결")
-    public void connect(MessageDTO.Request messageRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
-        // TODO : 프로그램 실행 시, 모든 채팅방 연결.
-
-        String authUuid = accessor.getSessionAttributes().get("Authorization").toString();
-        int unreadMessageResponse = messageService.getAllUnreadMessages(authUuid);
-
-        System.out.println("UNREAD MESSAGE RESPONSE: " + unreadMessageResponse);
-        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
-        template.convertAndSend("/sub/" + authUuid, new MessageDTO.UnreadMessageResponse(unreadMessageResponse)); //convertAndSendToUser로 변경 가능
-        System.out.println("ACCESSOR(CONNECT): " + accessor.getSessionAttributes());
-        log.info("Connected to chat room with ID: {}", messageRequest.getChatRoomId());
-    }
-
-    @MessageMapping(value = "/customer/enter/connect")
-    @Operation(summary = "[신랑신부] 포트폴리오 아이디로 채팅방 입장(생성 및 입장)")
-    public void connectByCustomer(MessageDTO.PortfolioRequest messagePortfolioRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
-        Long portfolioId = messagePortfolioRequest.getPortfolioId();
-        chatRoomService.enterChatRoomByPortfolioId(portfolioId);
-        log.info("Entered chat room for customer with portfolio ID: {}", portfolioId);
-
-        // TODO : wp sub 대신 send to
-    }
+//    @MessageMapping(value = "/shared/connect")
+//    @Operation(summary = "채팅방 연결")
+//    public void connect(MessageDTO.Request messageRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
+//        // TODO : 프로그램 실행 시, 모든 채팅방 연결.
+//
+//        String authUuid = accessor.getSessionAttributes().get("Authorization").toString();
+//        int unreadMessageResponse = messageService.getAllUnreadMessages(authUuid);
+//
+//        System.out.println("UNREAD MESSAGE RESPONSE: " + unreadMessageResponse);
+//        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
+//        template.convertAndSend("/sub/" + authUuid, new MessageDTO.UnreadMessageResponse(unreadMessageResponse)); //convertAndSendToUser로 변경 가능
+//        System.out.println("ACCESSOR(CONNECT): " + accessor.getSessionAttributes());
+//        log.info("Connected to chat room with ID: {}", messageRequest.getChatRoomId());
+//    }
+//
+//    @MessageMapping(value = "/customer/enter/connect")
+//    @Operation(summary = "[신랑신부] 포트폴리오 아이디로 채팅방 입장(생성 및 입장)")
+//    public void connectByCustomer(MessageDTO.PortfolioRequest messagePortfolioRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
+//        Long portfolioId = messagePortfolioRequest.getPortfolioId();
+//        chatRoomService.enterChatRoomByPortfolioId(portfolioId);
+//        log.info("Entered chat room for customer with portfolio ID: {}", portfolioId);
+//    }
 
 
-    @MessageMapping(value = "/customer/enter")
-    @Operation(summary = "[신랑신부] 채팅방 입장")
-    public void enterByCustomer(MessageDTO.Request messageRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
-        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
-
-        log.trace("ACCESSOR(SEND): {}", accessor.getSessionAttributes());
-        String customerUuid = accessor.getSessionAttributes().get("Authorization").toString();
-
-        messageService.enterChatRoom(messageRequest, customerUuid);
-
-        log.info("Entered chat room with ID: {}", messageRequest.getChatRoomId());
-    }
-
-    @MessageMapping(value = "/weddinplanner/enter")
-    @Operation(summary = "[웨딩플래너] 채팅방 입장")
-    public void enterByWeddingPlanner(MessageDTO.Request messageRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
-        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
-
-        log.debug("ACCESSOR(SEND): {}", accessor.getSessionAttributes());
-        String weddingPlannerUuid = accessor.getSessionAttributes().get("Authorization").toString();
-
-        messageService.enterChatRoom(messageRequest, weddingPlannerUuid);
-
-        log.info("Entered chat room with ID: {}", messageRequest.getChatRoomId());
-    }
+//    @MessageMapping(value = "/customer/enter")
+//    @Operation(summary = "[신랑신부] 채팅방 입장")
+//    public void enterByCustomer(MessageDTO.Request messageRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
+//        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
+//
+//        log.trace("ACCESSOR(SEND): {}", accessor.getSessionAttributes());
+//        String customerUuid = accessor.getSessionAttributes().get("Authorization").toString();
+//
+//        messageService.enterChatRoom(messageRequest, customerUuid);
+//
+//        log.info("Entered chat room with ID: {}", messageRequest.getChatRoomId());
+//    }
+//
+//    @MessageMapping(value = "/weddinplanner/enter")
+//    @Operation(summary = "[웨딩플래너] 채팅방 입장")
+//    public void enterByWeddingPlanner(MessageDTO.Request messageRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
+//        template.convertAndSend("/sub/" + messageRequest.getChatRoomId(), messageRequest);
+//
+//        log.debug("ACCESSOR(SEND): {}", accessor.getSessionAttributes());
+//        String weddingPlannerUuid = accessor.getSessionAttributes().get("Authorization").toString();
+//
+//        messageService.enterChatRoom(messageRequest, weddingPlannerUuid);
+//
+//        log.info("Entered chat room with ID: {}", messageRequest.getChatRoomId());
+//    }
 
     @MessageMapping(value = "/customer/send")
     @Operation(summary = "[신랑신부] 메세지 전송")

--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -71,6 +71,9 @@ public class ChatRoomService {
         String weddingPlannerUuid = weddingPlanner.getUUID();
         boolean isConnected = StompPreHandler.isUserConnected(weddingPlannerUuid);
 
+        log.info("Wedding Planner UUID: {}", weddingPlannerUuid);
+        log.info("Connected: {}", isConnected);
+
         if (isConnected) {
             MessageDTO.Request messageRequest = MessageDTO.Request.builder()
                     .chatRoomId(chatRoomId)

--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -81,7 +81,7 @@ public class ChatRoomService {
 
         chatRoom.setCustomer(customer);
         chatRoom.setWeddingPlanner(weddingPlanner);
-        
+
         chatRoomRepository.save(chatRoom);
         log.info("Created chat room with ID: {}", chatRoom.getId());
 
@@ -150,6 +150,14 @@ public class ChatRoomService {
         log.info("Getting chat room ID for customer ID: {} and wedding planner ID: {}", customer.getId(), weddingPlanner.getId());
         ChatRoom chatRoom = chatRoomRepository.findByCustomerIdAndWeddingPlannerId(customer.getId(), weddingPlanner.getId());
         return chatRoom.getId();
+    }
+
+    public ChatRoomDTO.Response getMessagesByChatRoomId(Long chatRoomId) {
+        log.info("Fetching messages by chat room ID: {}", chatRoomId);
+        ChatRoom chatRoom = getChatRoomById(chatRoomId);
+
+        updateOppositeReadFlag(chatRoom);
+        return getMessagesByChatRoom(chatRoom);
     }
 
     public ChatRoomDTO.Response getMessagesByChatRoom(ChatRoom chatRoom) {

--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -108,7 +108,7 @@ public class ChatRoomService {
         ChatRoom chatRoom = getChatRoomById(chatRoomId);
 
         updateOppositeReadFlag(chatRoom);
-        return getMessagesByChatRoom(chatRoom);
+        return getMessagesByChatRoomForCustomer(chatRoom);
     }
 
     public ChatRoomDTO.Response createChatRoomByPortfolioId(Customer customer, WeddingPlanner weddingPlanner) {
@@ -187,17 +187,42 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findByCustomerIdAndWeddingPlannerId(customer.getId(), weddingPlanner.getId());
         return chatRoom.getId();
     }
-
-    public ChatRoomDTO.Response getMessagesByChatRoomId(Long chatRoomId) {
+    
+    public ChatRoomDTO.Response getMessagesByChatRoomIdForCustomer(Long chatRoomId) {
         log.info("Fetching messages by chat room ID: {}", chatRoomId);
         ChatRoom chatRoom = getChatRoomById(chatRoomId);
 
         updateOppositeReadFlag(chatRoom);
-        return getMessagesByChatRoom(chatRoom);
+        return getMessagesByChatRoomForCustomer(chatRoom);
     }
 
-    public ChatRoomDTO.Response getMessagesByChatRoom(ChatRoom chatRoom) {
+    public ChatRoomDTO.Response getMessagesByChatRoomIdForWeddingPlanner(Long chatRoomId) {
+        log.info("Fetching messages by chat room ID: {}", chatRoomId);
+        ChatRoom chatRoom = getChatRoomById(chatRoomId);
+
+        updateOppositeReadFlag(chatRoom);
+        return getMessagesByChatRoomForWeddingPlanner(chatRoom);
+    }
+
+    public ChatRoomDTO.Response getMessagesByChatRoomForCustomer(ChatRoom chatRoom) {
         String Uuid = customUserDetailsService.getCurrentAuthenticatedCustomer().getUUID();
+        chatRoom.addUser(Uuid);
+
+        chatRoomRepository.save(chatRoom);
+
+        List<Message> messages = chatRoom.getMessages();
+        List<MessageDTO.Response> messageResponses = messages.stream()
+                .map(messageMapper::entityToResponse)// set clubId to each Response
+                .collect(Collectors.toList());
+
+        ChatRoomDTO.Response response = chatRoomMapper.entityToResponse(chatRoom);
+        response.setMessages(messageResponses);
+
+        return response;
+    }
+
+    public ChatRoomDTO.Response getMessagesByChatRoomForWeddingPlanner(ChatRoom chatRoom) {
+        String Uuid = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner().getUUID();
         chatRoom.addUser(Uuid);
 
         chatRoomRepository.save(chatRoom);

--- a/demo/src/main/java/com/example/demo/chat/service/MessageService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/MessageService.java
@@ -10,15 +10,11 @@ import com.example.demo.chat.mapper.MessageMapper;
 import com.example.demo.chat.repository.ChatRoomRepository;
 import com.example.demo.chat.repository.MessageRepository;
 import com.example.demo.enums.member.MemberRole;
-import com.example.demo.member.service.CustomUserDetailsService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +27,6 @@ public class MessageService {
 
     private final ChatRoomMapper chatRoomMapper = ChatRoomMapper.INSTANCE;
     private final ChatRoomRepository chatRoomRepository;
-
 
     @Transactional
     public MessageDTO.Response sendMessageByCustomer(MessageDTO.Request messageRequest, String Uuid) {

--- a/demo/src/main/java/com/example/demo/member/repository/WeddingPlannerRepository.java
+++ b/demo/src/main/java/com/example/demo/member/repository/WeddingPlannerRepository.java
@@ -11,4 +11,5 @@ public interface WeddingPlannerRepository extends JpaRepository<WeddingPlanner, 
 
     Optional<WeddingPlanner> findByUUID(String separator);
 
+    Optional<WeddingPlanner> findByPortfolioId(Long portfolioId);
 }


### PR DESCRIPTION
### PR 요약
- 채팅방 입장에 대한 API
### 변경 사항
**Flow**
- (Customer) Portfolio를 통해 입장하는 경우
   - ~~상대방이 connected: sendToUser로 프론트에 ENTER 시그널 보내서 프론트가 sub 요청~~
   - 상대방이 connected: /sub/{weddingPlannerUUID} 토픽에 ENTER 시그널 보내서 프론트가 sub 요청
- (Shared) 채팅방 목록을 통해 입장하는 경우

**공통 로직**
- readFlag 갱신 및 자신 UUID chatRoom에 넣어주기
- 메세지 리스트 불러오기

### 참고 사항
- ~~추후 sendToUser에 UUID를 넣을 수 있도록, context에 Member 등록 필요~~