### PR TITLE
fix/remove url for resource favicon.ico

### DIFF
--- a/demo/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig{
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests(authorize -> authorize
                     .requestMatchers("/api/v1/auth/shared/create").permitAll()
-                    .requestMatchers("/", "/index.html","/weddingplanner-chat.html","/customer-chat.html", "/swagger-ui/*",  "/swagger-resources/**", "/v3/api-docs/**", "/favicon.ico").permitAll()
+                    .requestMatchers("/", "/index.html","/weddingplanner-chat.html","/customer-chat.html", "/swagger-ui/*",  "/swagger-resources/**", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/api/v1/*/shared/**").hasAnyRole("CUSTOMER","WEDDING_PLANNER")
                     .requestMatchers("/api/v1/*/weddingplanner/**").hasRole("WEDDING_PLANNER")
                     .requestMatchers("/api/v1/*/customer/**").hasRole("CUSTOMER")


### PR DESCRIPTION
### PR 요약
cd 오류 해결을 위한 PR

### 변경 사항
favicon.ico url은 사용하지 않아 삭제하였습니다.

### 참고 사항
**web.stdout.log** 오류 내용
`Aug 12 15:08:29 ip-172-31-39-7 web[2113]: org.springframework.dao.InvalidDataAccessResourceUsageException: could not execute statement [Unknown column 'last_message_content' in 'field list'] [insert into chat_room (created_at,customer_id,is_deleted,last_message_content,last_message_created_at,updated_at,weddingplanner_id) values (?,?,?,?,?,?,?)]; SQL [insert into chat_room (created_at,customer_id,is_deleted,last_message_content,last_message_created_at,updated_at,weddingplanner_id) values (?,?,?,?,?,?,?)]
`
해당 CD 오류는 RDS DB jpa-ddl-auto 설정이 꼬이면서 생긴 오류라 판단되어 RDS table을 전부 drop한 후 재배포 하여 해결하였습니다.