### PR TITLE
Feat/Leave chatroom and update user id fields

### DIFF
--- a/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -73,10 +74,26 @@ public class ChatRoomController {
     // TODO : 현재 유저만 나가야 함.
     // TODO : 메소드 명, API route 변경
     @PostMapping("/shared/delete/{chatRoomId}")
-    @Operation(summary = "특정 채팅방 나가기")
+    @Operation(summary = "[공통] 특정 채팅방 삭제")
     public ResponseEntity<Void> deleteChatRoom(@PathVariable Long chatRoomId) {
         chatRoomService.deleteChatRoom(chatRoomId);
         log.info("Deleted chat room with ID: {}", chatRoomId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/customer/leave/{chatRoomId}")
+    @Operation(summary = "[신랑신부] 특정 채팅방 나가기")
+    public ResponseEntity<List<ChatRoomOverviewDTO.Response>> leaveChatRoomForCustomer(@PathVariable Long chatRoomId) {
+        List<ChatRoomOverviewDTO.Response> currentUsersAllChatRoom = chatRoomService.leaveChatRoomForCustomer(chatRoomId);
+        log.info("Left chat room with ID: {}", chatRoomId);
+        return ResponseEntity.status(200).body(currentUsersAllChatRoom);
+    }
+
+    @GetMapping("/weddingplanner/leave/{chatRoomId}")
+    @Operation(summary = "[웨딩플래너] 특정 채팅방 나가기")
+    public ResponseEntity<List<ChatRoomOverviewDTO.Response>> leaveChatRoomForWeddingPlanner(@PathVariable Long chatRoomId) {
+        List<ChatRoomOverviewDTO.Response> currentUsersAllChatRoom = chatRoomService.leaveChatRoomForWeddingPlanner(chatRoomId);
+        log.info("Left chat room with ID: {}", chatRoomId);
+        return ResponseEntity.status(200).body(currentUsersAllChatRoom);
     }
 }

--- a/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/ChatRoomController.java
@@ -80,20 +80,4 @@ public class ChatRoomController {
         log.info("Deleted chat room with ID: {}", chatRoomId);
         return ResponseEntity.noContent().build();
     }
-
-    @GetMapping("/customer/leave/{chatRoomId}")
-    @Operation(summary = "[신랑신부] 특정 채팅방 나가기")
-    public ResponseEntity<List<ChatRoomOverviewDTO.Response>> leaveChatRoomForCustomer(@PathVariable Long chatRoomId) {
-        List<ChatRoomOverviewDTO.Response> currentUsersAllChatRoom = chatRoomService.leaveChatRoomForCustomer(chatRoomId);
-        log.info("Left chat room with ID: {}", chatRoomId);
-        return ResponseEntity.status(200).body(currentUsersAllChatRoom);
-    }
-
-    @GetMapping("/weddingplanner/leave/{chatRoomId}")
-    @Operation(summary = "[웨딩플래너] 특정 채팅방 나가기")
-    public ResponseEntity<List<ChatRoomOverviewDTO.Response>> leaveChatRoomForWeddingPlanner(@PathVariable Long chatRoomId) {
-        List<ChatRoomOverviewDTO.Response> currentUsersAllChatRoom = chatRoomService.leaveChatRoomForWeddingPlanner(chatRoomId);
-        log.info("Left chat room with ID: {}", chatRoomId);
-        return ResponseEntity.status(200).body(currentUsersAllChatRoom);
-    }
 }

--- a/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/MessageController.java
@@ -1,6 +1,7 @@
 package com.example.demo.chat.controller;
 
 import com.example.demo.chat.dto.MessageDTO;
+import com.example.demo.chat.service.ChatRoomService;
 import com.example.demo.chat.service.MessageService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class MessageController {
     private final MessageService messageService;
+    private final ChatRoomService chatRoomService;
 
     @MessageMapping(value = "/customer/send")
     @Operation(summary = "[신랑신부] 메세지 전송")
@@ -34,4 +36,21 @@ public class MessageController {
         log.info("WeddingPlanner sent message to chat room with ID: {}", messageRequest.getChatRoomId());
     }
 
+    @MessageMapping(value = "/customer/leave")
+    @Operation(summary = "[신랑신부] 채팅방 나가기")
+    public void leaveByCustomer(MessageDTO.Request messageRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
+        String customerUuid = accessor.getSessionAttributes().get("Authorization").toString();
+
+        messageService.leaveChatRoomForCustomer(messageRequest, customerUuid);
+        log.info("Customer left chat room with ID: {}", messageRequest.getChatRoomId());
+    }
+
+    @MessageMapping(value = "/weddingplanner/leave")
+    @Operation(summary = "[웨딩플래너] 채팅방 나가기")
+    public void leaveByWeddingPlanner(MessageDTO.Request messageRequest, @DestinationVariable SimpMessageHeaderAccessor accessor) {
+        String weddingPlannerUuid = accessor.getSessionAttributes().get("Authorization").toString();
+
+        messageService.leaveChatRoomForWeddingPlanner(messageRequest, weddingPlannerUuid);
+        log.info("WeddingPlanner left chat room with ID: {}", messageRequest.getChatRoomId());
+    }
 }

--- a/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/ChatRoom.java
@@ -52,7 +52,7 @@ public class ChatRoom extends BaseTimeEntity {
 
     public void addMessage(Message message) {
         messages.add(message);
-        this.lastMessageContent = message.getContents();
+        this.lastMessageContent = message.getContent();
         this.lastMessageCreatedAt = message.getCreatedAt();
     }
 

--- a/demo/src/main/java/com/example/demo/chat/domain/Message.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/Message.java
@@ -27,7 +27,7 @@ public class Message extends BaseTimeEntity {
     private boolean isDeleted = Boolean.FALSE;
 
     private MessageType messageType;
-    private String contents;
+    private String content;
 
     private boolean oppositeReadFlag;
 

--- a/demo/src/main/java/com/example/demo/chat/dto/ChatRoomDTO.java
+++ b/demo/src/main/java/com/example/demo/chat/dto/ChatRoomDTO.java
@@ -30,7 +30,5 @@ public class ChatRoomDTO {
         private List<MessageDTO.Response> messages;
 
         private HashSet<String> userIds;
-
-        private Long chatRoomId;
     }
 }

--- a/demo/src/main/java/com/example/demo/chat/dto/ChatRoomDTO.java
+++ b/demo/src/main/java/com/example/demo/chat/dto/ChatRoomDTO.java
@@ -29,6 +29,7 @@ public class ChatRoomDTO {
     public static class Response {
         private List<MessageDTO.Response> messages;
 
+        // TODO : isOppositeConnected 로 변경 여지
         private HashSet<String> userIds;
     }
 }

--- a/demo/src/main/java/com/example/demo/chat/dto/ChatRoomOverviewDTO.java
+++ b/demo/src/main/java/com/example/demo/chat/dto/ChatRoomOverviewDTO.java
@@ -46,5 +46,9 @@ public class ChatRoomOverviewDTO {
 
         @Schema(type = "integer", example = "2")
         private Long portfolioId;
+
+        // TODO : user role 구분해서 다르게 처리
+        @Schema(type = "integer", example = "2")
+        private Integer unreadMessageCount;
     }
 }

--- a/demo/src/main/java/com/example/demo/chat/dto/ChatRoomOverviewDTO.java
+++ b/demo/src/main/java/com/example/demo/chat/dto/ChatRoomOverviewDTO.java
@@ -47,7 +47,6 @@ public class ChatRoomOverviewDTO {
         @Schema(type = "integer", example = "2")
         private Long portfolioId;
 
-        // TODO : user role 구분해서 다르게 처리
         @Schema(type = "integer", example = "2")
         private Integer unreadMessageCount;
     }

--- a/demo/src/main/java/com/example/demo/chat/dto/MessageDTO.java
+++ b/demo/src/main/java/com/example/demo/chat/dto/MessageDTO.java
@@ -33,23 +33,9 @@ public class MessageDTO {
 
         private MemberRole senderRole;
 
-        private MessageType messageType;
-
         private String contents;
-
-        private Long chatRoomId;
     }
 
-    @Getter
-    @Setter
-    @ToString
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class UnreadMessageResponse {
-
-        private int unreadMessageCount;
-    }
 
     @Getter
     @Setter

--- a/demo/src/main/java/com/example/demo/chat/dto/MessageDTO.java
+++ b/demo/src/main/java/com/example/demo/chat/dto/MessageDTO.java
@@ -17,7 +17,7 @@ public class MessageDTO {
 
         private MessageType messageType;
 
-        private String contents;
+        private String content;
 
         private Long chatRoomId;
     }
@@ -33,7 +33,7 @@ public class MessageDTO {
 
         private MemberRole senderRole;
 
-        private String contents;
+        private String content;
     }
 
 

--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -8,7 +8,6 @@ import com.example.demo.chat.dto.MessageDTO;
 import com.example.demo.chat.mapper.ChatRoomMapper;
 import com.example.demo.chat.mapper.MessageMapper;
 import com.example.demo.chat.repository.ChatRoomRepository;
-import com.example.demo.chat.repository.MessageRepository;
 import com.example.demo.config.StompPreHandler;
 import com.example.demo.enums.chat.MessageType;
 import com.example.demo.enums.member.MemberRole;
@@ -27,8 +26,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -109,7 +106,6 @@ public class ChatRoomService {
         log.info("Chat room exists, entering existing chat room with ID: {}", chatRoomId);
         ChatRoom chatRoom = getChatRoomById(chatRoomId);
 
-        updateOppositeReadFlag(chatRoom);
         return getMessagesByChatRoomForCustomer(chatRoom);
     }
 
@@ -141,7 +137,7 @@ public class ChatRoomService {
                 .reduce(0, Integer::sum);
     }
 
-    public Integer getWeddingPlanners(String weddingPlannerUuid) {
+    public Integer getWeddingPlannersUnreadCount(String weddingPlannerUuid) {
         log.info("Fetching all chat rooms's unreadMessages for wedding planner");
         WeddingPlanner weddingPlanner = customUserDetailsService.getWeddingPlannerByUuid(weddingPlannerUuid);
         List<ChatRoom> chatRooms = chatRoomRepository.findByWeddingPlannerId(weddingPlanner.getId());
@@ -171,6 +167,7 @@ public class ChatRoomService {
                             .lastMessageCreatedAt(chatRoom.getLastMessageCreatedAt())
                             .organizationName(portfolioResponse.getOrganization())
                             .portfolioId(portfolioResponse.getId())
+                            .unreadMessageCount(getCustomersUnreadCount(customer.getUUID()))
                             .build();
                 })
                 .collect(Collectors.toList());
@@ -191,6 +188,7 @@ public class ChatRoomService {
                             .othersName(customer.getName())
                             .lastMessage(chatRoom.getLastMessageContent())
                             .lastMessageCreatedAt(chatRoom.getLastMessageCreatedAt())
+                            .unreadMessageCount(getWeddingPlannersUnreadCount(weddingPlanner.getUUID()))
                             .build();
                 })
                 .collect(Collectors.toList());

--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -195,28 +195,6 @@ public class ChatRoomService {
                 .collect(Collectors.toList());
     }
 
-    public List<ChatRoomOverviewDTO.Response> leaveChatRoomForCustomer(Long chatRoomId) {
-        log.info("Leaving chat room for customer with chat room ID: {}", chatRoomId);
-        ChatRoom chatRoom = getChatRoomById(chatRoomId);
-        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
-
-        chatRoom.removeUser(customer.getUUID());
-        chatRoomRepository.save(chatRoom);
-
-        return getCustomersAllChatRoom();
-    }
-
-    public List<ChatRoomOverviewDTO.Response> leaveChatRoomForWeddingPlanner(Long chatRoomId) {
-        log.info("Leaving chat room for wedding planner with chat room ID: {}", chatRoomId);
-        ChatRoom chatRoom = getChatRoomById(chatRoomId);
-        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
-
-        chatRoom.removeUser(weddingPlanner.getUUID());
-        chatRoomRepository.save(chatRoom);
-
-        return getWeddingPlannersAllChatRoom();
-    }
-
     public Long getChatRoomIdByCustomerAndWeddingPlanner(Customer customer, WeddingPlanner weddingPlanner) {
         log.info("Getting chat room ID for customer ID: {} and wedding planner ID: {}", customer.getId(), weddingPlanner.getId());
         ChatRoom chatRoom = chatRoomRepository.findByCustomerIdAndWeddingPlannerId(customer.getId(), weddingPlanner.getId());
@@ -286,7 +264,6 @@ public class ChatRoomService {
             }
         }
     }
-
 
     public void deleteChatRoom(Long chatRoomId) {
         log.info("Deleting chat room with ID: {}", chatRoomId);

--- a/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatRoomService.java
@@ -99,7 +99,7 @@ public class ChatRoomService {
 
             sendNewChatRoomTrigger(portfolioId, chatRoom.getId());
 
-            return createdChatRoomResponse;
+            return getMessagesByChatRoomForCustomer(chatRoom);
         }
 
         Long chatRoomId = getChatRoomIdByCustomerAndWeddingPlanner(customer, weddingPlanner);
@@ -115,6 +115,7 @@ public class ChatRoomService {
 
         chatRoom.setCustomer(customer);
         chatRoom.setWeddingPlanner(weddingPlanner);
+        chatRoom.setMessages(List.of());
 
         chatRoomRepository.save(chatRoom);
         log.info("Created chat room with ID: {}", chatRoom.getId());
@@ -194,6 +195,28 @@ public class ChatRoomService {
                 .collect(Collectors.toList());
     }
 
+    public List<ChatRoomOverviewDTO.Response> leaveChatRoomForCustomer(Long chatRoomId) {
+        log.info("Leaving chat room for customer with chat room ID: {}", chatRoomId);
+        ChatRoom chatRoom = getChatRoomById(chatRoomId);
+        Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
+
+        chatRoom.removeUser(customer.getUUID());
+        chatRoomRepository.save(chatRoom);
+
+        return getCustomersAllChatRoom();
+    }
+
+    public List<ChatRoomOverviewDTO.Response> leaveChatRoomForWeddingPlanner(Long chatRoomId) {
+        log.info("Leaving chat room for wedding planner with chat room ID: {}", chatRoomId);
+        ChatRoom chatRoom = getChatRoomById(chatRoomId);
+        WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
+
+        chatRoom.removeUser(weddingPlanner.getUUID());
+        chatRoomRepository.save(chatRoom);
+
+        return getWeddingPlannersAllChatRoom();
+    }
+
     public Long getChatRoomIdByCustomerAndWeddingPlanner(Customer customer, WeddingPlanner weddingPlanner) {
         log.info("Getting chat room ID for customer ID: {} and wedding planner ID: {}", customer.getId(), weddingPlanner.getId());
         ChatRoom chatRoom = chatRoomRepository.findByCustomerIdAndWeddingPlannerId(customer.getId(), weddingPlanner.getId());
@@ -217,6 +240,7 @@ public class ChatRoomService {
     }
 
     public ChatRoomDTO.Response getMessagesByChatRoomForCustomer(ChatRoom chatRoom) {
+        log.info("Fetching messages by chat room for customer");
         String Uuid = customUserDetailsService.getCurrentAuthenticatedCustomer().getUUID();
         chatRoom.addUser(Uuid);
 
@@ -234,6 +258,7 @@ public class ChatRoomService {
     }
 
     public ChatRoomDTO.Response getMessagesByChatRoomForWeddingPlanner(ChatRoom chatRoom) {
+        log.info("Fetching messages by chat room for wedding planner");
         String Uuid = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner().getUUID();
         chatRoom.addUser(Uuid);
 

--- a/demo/src/main/java/com/example/demo/chat/service/MessageService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/MessageService.java
@@ -83,7 +83,7 @@ public class MessageService {
         // TODO : Redis로 변경
         chatRoom.addUser(Uuid);
         chatRoom.addMessage(message);
-        chatRoom.setLastMessageContent(message.getContents());
+        chatRoom.setLastMessageContent(message.getContent());
         chatRoom.setLastMessageCreatedAt(message.getCreatedAt());
 
         chatRoomRepository.save(chatRoom);
@@ -97,10 +97,6 @@ public class MessageService {
         chatRoomRepository.save(chatRoom);
 
         return chatRoomMapper.entityToResponse(chatRoom);
-    }
-
-    public int getAllUnreadMessages(String uuid) {
-        return chatRoomService.getCustomersUnreadMessages(uuid);
     }
 
 }

--- a/demo/src/main/java/com/example/demo/chat/service/MessageService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/MessageService.java
@@ -4,6 +4,7 @@ package com.example.demo.chat.service;
 import com.example.demo.chat.domain.ChatRoom;
 import com.example.demo.chat.domain.Message;
 import com.example.demo.chat.dto.ChatRoomDTO;
+import com.example.demo.chat.dto.ChatRoomOverviewDTO;
 import com.example.demo.chat.dto.MessageDTO;
 import com.example.demo.chat.mapper.ChatRoomMapper;
 import com.example.demo.chat.mapper.MessageMapper;
@@ -19,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -89,12 +92,23 @@ public class MessageService {
         return messageMapper.entityToResponse(message);
     }
 
-    public ChatRoomDTO.Response enterChatRoom(MessageDTO.Request messageRequest, String Uuid) {
-        ChatRoom chatRoom = chatRoomService.getChatRoomById(messageRequest.getChatRoomId());
+    public void leaveChatRoomForCustomer(MessageDTO.Request messageRequest, String customerUuid) {
+        log.info("Leaving chat room for customer with chat room ID: {}", messageRequest.getChatRoomId());
+        ChatRoom chatRoom = chatRoomRepository.findById(messageRequest.getChatRoomId())
+                .orElseThrow();
 
+        chatRoom.removeUser(customerUuid);
         chatRoomRepository.save(chatRoom);
-
-        return chatRoomMapper.entityToResponse(chatRoom);
     }
+
+    public void leaveChatRoomForWeddingPlanner(MessageDTO.Request messageRequest, String weddingPlannerUuid) {
+        log.info("Leaving chat room for wedding planner with chat room ID: {}", messageRequest.getChatRoomId());
+        ChatRoom chatRoom = chatRoomRepository.findById(messageRequest.getChatRoomId())
+                .orElseThrow();
+
+        chatRoom.removeUser(weddingPlannerUuid);
+        chatRoomRepository.save(chatRoom);
+    }
+
 
 }

--- a/demo/src/main/java/com/example/demo/chat/service/MessageService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/MessageService.java
@@ -37,33 +37,31 @@ public class MessageService {
 
 
     @Transactional
-    public MessageDTO.Response sendMessageByCustomer(MessageDTO.Request messageRequest, String Uuid) {
+    public MessageDTO.Response sendMessageByCustomer(MessageDTO.Request messageRequest, String customerUuid) {
         messageRequest.setSenderRole(MemberRole.CUSTOMER);
 
         ChatRoom chatRoom = chatRoomRepository.findById(messageRequest.getChatRoomId()).orElseThrow();
         WeddingPlanner weddingPlanner = chatRoom.getWeddingPlanner();
         boolean isOppositeConnected = StompPreHandler.isUserConnected(weddingPlanner.getUUID());
 
-        if (isOppositeConnected) {
-            return sendMessage(messageRequest, Uuid);
+        if (!isOppositeConnected) {
+            // TODO : FCM
         }
-        // TODO : FCM
-        return null;
+        return sendMessage(messageRequest, customerUuid);
     }
 
     @Transactional
-    public MessageDTO.Response sendMessageByWeddingPlanner(MessageDTO.Request messageRequest, String Uuid) {
+    public MessageDTO.Response sendMessageByWeddingPlanner(MessageDTO.Request messageRequest, String weddingPlannerUuid) {
         messageRequest.setSenderRole(MemberRole.WEDDING_PLANNER);
 
         ChatRoom chatRoom = chatRoomRepository.findById(messageRequest.getChatRoomId()).orElseThrow();
         Customer customer = chatRoom.getCustomer();
         boolean isOppositeConnected = StompPreHandler.isUserConnected(customer.getUUID());
 
-        if (isOppositeConnected) {
-            return sendMessage(messageRequest, Uuid);
+        if (!isOppositeConnected) {
+            // TODO : FCM
         }
-        // TODO : FCM
-        return null;
+        return sendMessage(messageRequest, weddingPlannerUuid);
     }
 
     public MessageDTO.Response sendMessage(MessageDTO.Request messageRequest, String Uuid) {

--- a/demo/src/main/java/com/example/demo/dummy/DataLoader.java
+++ b/demo/src/main/java/com/example/demo/dummy/DataLoader.java
@@ -216,7 +216,7 @@ public class DataLoader implements CommandLineRunner {
         wishListRepository.save(wishList2);
 
         Message message1 = Message.builder()
-                .contents("웨딩플래너 님 안녕하세요!")
+                .content("웨딩플래너 님 안녕하세요!")
                 .messageType(MessageType.SEND)
                 .isDeleted(false)
                 .oppositeReadFlag(true)
@@ -224,7 +224,7 @@ public class DataLoader implements CommandLineRunner {
                 .build();
 
         Message message2 = Message.builder()
-                .contents("안녕하세요! 어떻게 도와드릴까요?")
+                .content("안녕하세요! 어떻게 도와드릴까요?")
                 .messageType(MessageType.SEND)
                 .isDeleted(false)
                 .oppositeReadFlag(false)

--- a/demo/src/main/java/com/example/demo/enums/chat/MessageType.java
+++ b/demo/src/main/java/com/example/demo/enums/chat/MessageType.java
@@ -1,8 +1,6 @@
 package com.example.demo.enums.chat;
 
 public enum MessageType{
-    CONNECT,
-    DISCONNECT,
     SEND,
     ENTER,
     LEAVE

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -213,4 +213,12 @@ public class CustomUserDetailsService implements UserDetailsService {
         log.info("Found customer with UUID: {}", uuid);
         return customer;
     }
+
+    public WeddingPlanner getWeddingPlannerByUuid(String uuid) {
+        log.info("Getting wedding planner by UUID: {}", uuid);
+        WeddingPlanner weddingPlanner = weddingPlannerRepository.findByUUID(uuid)
+                .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
+        log.info("Found wedding planner with UUID: {}", uuid);
+        return weddingPlanner;
+    }
 }

--- a/demo/src/main/resources/static/customer-chat.html
+++ b/demo/src/main/resources/static/customer-chat.html
@@ -93,7 +93,7 @@
             var chatRoomId = document.getElementById("chatRoomId").value;
             stompClient.subscribe('/sub/' + chatRoomId, function (message) {
                 var messageBody = JSON.parse(message.body);
-                showMessage(messageBody.contents, messageBody.senderRole);
+                showMessage(messageBody.content, messageBody.senderRole);
             });
             stompClient.subscribe('/sub/' + authToken, function (message) {
                 var messageBody = JSON.parse(message.body);
@@ -109,7 +109,7 @@
                 'messageType': 'SEND',
                 'chatRoomId': chatRoomId,
                 'senderRole': 'CUSTOMER',
-                'contents': 'Connected to chat room'
+                'content': 'Connected to chat room'
             }));
         });
     }
@@ -121,7 +121,7 @@
                 'messageType': 'DISCONNECT',
                 'chatRoomId': chatRoomId,
                 'senderRole': 'CUSTOMER',
-                'contents': 'Disconnected from chat room'
+                'content': 'Disconnected from chat room'
             }));
             stompClient.disconnect();
             console.log("Disconnected");
@@ -134,7 +134,7 @@
             'messageType': 'LEAVE',
             'chatRoomId': chatRoomId,
             'senderRole': 'CUSTOMER',
-            'contents': 'Left the chat room'
+            'content': 'Left the chat room'
         }));
     }
 
@@ -144,7 +144,7 @@
             'messageType': 'ENTER',
             'chatRoomId': chatRoomId,
             'senderRole': 'CUSTOMER',
-            'contents': 'Entered the chat room'
+            'content': 'Entered the chat room'
         }));
     }
 
@@ -155,7 +155,7 @@
             'messageType': 'SEND',
             'chatRoomId': chatRoomId,
             'senderRole': 'CUSTOMER',
-            'contents': message
+            'content': message
         }));
     }
 

--- a/demo/src/main/resources/static/customer-chat.html
+++ b/demo/src/main/resources/static/customer-chat.html
@@ -79,6 +79,11 @@
 <script>
     var stompClient = null;
 
+    function updateStatusIndicator(message) {
+        // Log the status as a chat message
+        showMessage(message, 'SYSTEM');
+    }
+
     function connect() {
         var socket = new SockJS('/stomp/chat');
         stompClient = Stomp.over(socket);
@@ -111,6 +116,9 @@
                 'senderRole': 'CUSTOMER',
                 'content': 'Connected to chat room'
             }));
+
+            // Update status
+            updateStatusIndicator('Connected to chat server.');
         });
     }
 
@@ -125,6 +133,7 @@
             }));
             stompClient.disconnect();
             console.log("Disconnected");
+            updateStatusIndicator('Disconnected from chat server.');
         }
     }
 
@@ -136,6 +145,7 @@
             'senderRole': 'CUSTOMER',
             'content': 'Left the chat room'
         }));
+        updateStatusIndicator('Left the chat room.');
     }
 
     function enter() {
@@ -146,6 +156,7 @@
             'senderRole': 'CUSTOMER',
             'content': 'Entered the chat room'
         }));
+        updateStatusIndicator('Entered the chat room.');
     }
 
     function sendMessage() {
@@ -169,6 +180,10 @@
 
         if (senderRole === 'CUSTOMER') {
             messageDiv.classList.add('message-sent');
+        } else if (senderRole === 'SYSTEM') {
+            messageDiv.classList.add('message-received');
+            messageDiv.style.backgroundColor = '#e2e3e5';
+            messageDiv.style.fontStyle = 'italic';
         } else {
             messageDiv.classList.add('message-received');
         }

--- a/demo/src/main/resources/static/customer-chat.html
+++ b/demo/src/main/resources/static/customer-chat.html
@@ -45,7 +45,6 @@
             </form>
             <button id="connect" class="btn btn-default" onclick="connect()">Connect</button>
             <button id="disconnect" class="btn btn-default" onclick="disconnect()">Disconnect</button>
-            <button id="enter" class="btn btn-default" onclick="enter()">Enter</button>
             <button id="leave" class="btn btn-default" onclick="leave()">Leave</button>
         </div>
         <div class="col-md-6">
@@ -139,7 +138,7 @@
 
     function leave() {
         var chatRoomId = document.getElementById("chatRoomId").value;
-        stompClient.send("/pub/shared/leave", {}, JSON.stringify({
+        stompClient.send("/pub/customer/leave", {}, JSON.stringify({
             'messageType': 'LEAVE',
             'chatRoomId': chatRoomId,
             'senderRole': 'CUSTOMER',

--- a/demo/src/main/resources/static/weddingplanner-chat.html
+++ b/demo/src/main/resources/static/weddingplanner-chat.html
@@ -93,7 +93,7 @@
             var chatRoomId = document.getElementById("chatRoomId").value;
             stompClient.subscribe('/sub/' + chatRoomId, function (message) {
                 var messageBody = JSON.parse(message.body);
-                showMessage(messageBody.contents, messageBody.senderRole);
+                showMessage(messageBody.content, messageBody.senderRole);
             });
 
             stompClient.subscribe('/sub/' + authToken, function (message) {
@@ -114,7 +114,7 @@
                 'messageType': 'DISCONNECT',
                 'chatRoomId': chatRoomId,
                 'senderRole': 'WEDDING_PLANNER',
-                'contents': 'Disconnected from chat room'
+                'content': 'Disconnected from chat room'
             }));
             stompClient.disconnect();
             console.log("Disconnected");
@@ -127,7 +127,7 @@
             'messageType': 'LEAVE',
             'chatRoomId': chatRoomId,
             'senderRole': 'WEDDING_PLANNER',
-            'contents': 'Left the chat room'
+            'content': 'Left the chat room'
         }));
     }
 
@@ -137,7 +137,7 @@
             'messageType': 'ENTER',
             'chatRoomId': chatRoomId,
             'senderRole': 'WEDDING_PLANNER',
-            'contents': 'Entered the chat room'
+            'content': 'Entered the chat room'
         }));
     }
 
@@ -148,7 +148,7 @@
             'messageType': 'SEND',
             'chatRoomId': chatRoomId,
             'senderRole': 'WEDDING_PLANNER',
-            'contents': message
+            'content': message
         }));
     }
 

--- a/demo/src/main/resources/static/weddingplanner-chat.html
+++ b/demo/src/main/resources/static/weddingplanner-chat.html
@@ -45,7 +45,6 @@
             </form>
             <button id="connect" class="btn btn-default" onclick="connect()">Connect</button>
             <button id="disconnect" class="btn btn-default" onclick="disconnect()">Disconnect</button>
-            <button id="enter" class="btn btn-default" onclick="enter()">Enter</button>
             <button id="leave" class="btn btn-default" onclick="leave()">Leave</button>
         </div>
         <div class="col-md-6">
@@ -130,7 +129,7 @@
 
     function leave() {
         var chatRoomId = document.getElementById("chatRoomId").value;
-        stompClient.send("/pub/shared/leave", {}, JSON.stringify({
+        stompClient.send("/pub/weddingplanner/leave", {}, JSON.stringify({
             'messageType': 'LEAVE',
             'chatRoomId': chatRoomId,
             'senderRole': 'WEDDING_PLANNER',

--- a/demo/src/main/resources/static/weddingplanner-chat.html
+++ b/demo/src/main/resources/static/weddingplanner-chat.html
@@ -79,6 +79,11 @@
 <script>
     var stompClient = null;
 
+    function updateStatusIndicator(message) {
+        // Log the status as a chat message
+        showMessage(message, 'SYSTEM');
+    }
+
     function connect() {
         var socket = new SockJS('/stomp/chat');
         stompClient = Stomp.over(socket);
@@ -90,6 +95,7 @@
 
         stompClient.connect(headers, function (frame) {
             console.log('Connected: ' + frame);
+            updateStatusIndicator('Connected to chat server.');
             var chatRoomId = document.getElementById("chatRoomId").value;
             stompClient.subscribe('/sub/' + chatRoomId, function (message) {
                 var messageBody = JSON.parse(message.body);
@@ -117,6 +123,7 @@
                 'content': 'Disconnected from chat room'
             }));
             stompClient.disconnect();
+            updateStatusIndicator('Disconnected from chat server.');
             console.log("Disconnected");
         }
     }
@@ -129,6 +136,7 @@
             'senderRole': 'WEDDING_PLANNER',
             'content': 'Left the chat room'
         }));
+        updateStatusIndicator('Left the chat room.');
     }
 
     function enter() {
@@ -139,12 +147,13 @@
             'senderRole': 'WEDDING_PLANNER',
             'content': 'Entered the chat room'
         }));
+        updateStatusIndicator('Entered the chat room.');
     }
 
     function sendMessage() {
         var chatRoomId = document.getElementById("chatRoomId").value;
         var message = document.getElementById("message").value;
-        stompClient.send("/pub/weddinplanner/send", {}, JSON.stringify({
+        stompClient.send("/pub/weddingplanner/send", {}, JSON.stringify({
             'messageType': 'SEND',
             'chatRoomId': chatRoomId,
             'senderRole': 'WEDDING_PLANNER',
@@ -162,6 +171,10 @@
 
         if (senderRole === 'WEDDING_PLANNER') {
             messageDiv.classList.add('message-sent');
+        } else if (senderRole === 'SYSTEM') {
+            messageDiv.classList.add('message-received');
+            messageDiv.style.backgroundColor = '#e2e3e5';
+            messageDiv.style.fontStyle = 'italic';
         } else {
             messageDiv.classList.add('message-received');
         }

--- a/demo/src/main/resources/static/weddingplanner-chat.html
+++ b/demo/src/main/resources/static/weddingplanner-chat.html
@@ -104,13 +104,6 @@
                 }
             });
 
-            // Send connection request
-            stompClient.send("/pub/shared/connect", headers, JSON.stringify({
-                'messageType': 'SEND',
-                'chatRoomId': chatRoomId,
-                'senderRole': 'WEDDING_PLANNER',
-                'contents': 'Connected to chat room'
-            }));
         });
     }
 

--- a/demo/src/test/java/com/example/demo/chat/controller/SocketConnectionTest.java
+++ b/demo/src/test/java/com/example/demo/chat/controller/SocketConnectionTest.java
@@ -106,7 +106,7 @@
 //        MessageDTO.Request body = MessageDTO.Request.builder()
 //                .id(1L)
 //                .messageType(MessageType.SEND)
-//                .contents("Hello, World!")
+//                .content("Hello, World!")
 //                .chatRoomId(1L)
 //                .build();
 //


### PR DESCRIPTION
### PR 요약
- 채팅 방을 나갈 때 userId 필드 갱신하도록 기능 구현

### 변경 사항
- Client에서 필요하지 않은 field 삭제
  - chatRoomId
  - messageType
  - chatRoomId
- 사용하지 않는 MessageType Enum 삭제
  - CONNECT
  - DISCONNECT
- 상대방 CONNECT 여부에 따라 FCM 분기 처리
- 상대방 CONNECT 여부 상관없이 web-socket queue 에 메세지 publishing
- chatroom 목록 호출 시, unreadCount 함께 반환
- 테스트 페이지(customer-chat.html, weddingplanner-chat.html)에 status 로깅 추가

### 참고 사항
- [Feat/enter chatroom and send message #64](https://github.com/dears-swm-15th/dears-core-api/pull/64)
- [Feat/Chatting by web-socket with stomp protocol #104](https://github.com/dears-swm-15th/dears-core-api/pull/104)

