### PR TITLE
Feat/Add customer service message handling and Discord integration

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -39,8 +39,6 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-//	implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
-
 //  swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
@@ -97,6 +95,11 @@ dependencies {
     // prometheus & grafana
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // 	discord-feign
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.1'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
 }
 
 tasks.named('test') {

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
-    // 	discord-feign
+    // 	discord
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.1'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 

--- a/demo/src/main/java/com/example/demo/DemoApplication.java
+++ b/demo/src/main/java/com/example/demo/DemoApplication.java
@@ -1,11 +1,19 @@
 package com.example.demo;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.commons.httpclient.HttpClientConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients(basePackages = "com.example.demo.discord.event")
+@ImportAutoConfiguration({FeignAutoConfiguration.class, HttpClientConfiguration.class})
+@EnableAspectJAutoProxy
 public class DemoApplication {
 
     public static void main(String[] args) {

--- a/demo/src/main/java/com/example/demo/DemoApplication.java
+++ b/demo/src/main/java/com/example/demo/DemoApplication.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.commons.httpclient.HttpClientConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -17,7 +18,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 public class DemoApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(DemoApplication.class, args);
+        ApplicationContext context = SpringApplication.run(DemoApplication.class, args);
     }
-
 }
+

--- a/demo/src/main/java/com/example/demo/discord/DiscordMessage.java
+++ b/demo/src/main/java/com/example/demo/discord/DiscordMessage.java
@@ -1,9 +1,52 @@
 package com.example.demo.discord;
 
+import java.util.List;
+
 public record DiscordMessage(
-        String content
+        String content,
+        List<Embed> embeds
 ) {
-    public static DiscordMessage createCustomerServiceMessage(String message) {
-        return new DiscordMessage(message);
+
+    public static DiscordMessage createCustomerServiceMessage(String message, List<Embed> embeds) {
+        return new DiscordMessage(message, embeds);
+    }
+
+    public static record Embed(
+            String title,
+            String description,
+            int color,
+            Footer footer,
+//            Image image,
+//            Thumbnail thumbnail,
+            Author author
+//            List<Field> fields
+    ) {
+    }
+
+    public static record Footer(
+            String text
+    ) {
+    }
+
+    public static record Image(
+            String url
+    ) {
+    }
+
+    public static record Thumbnail(
+            String url
+    ) {
+    }
+
+    public static record Author(
+            String name
+    ) {
+    }
+
+    public static record Field(
+            String name,
+            String time,
+            boolean inline
+    ) {
     }
 }

--- a/demo/src/main/java/com/example/demo/discord/DiscordMessage.java
+++ b/demo/src/main/java/com/example/demo/discord/DiscordMessage.java
@@ -1,0 +1,9 @@
+package com.example.demo.discord;
+
+public record DiscordMessage(
+        String content
+) {
+    public static DiscordMessage createCustomerServiceMessage(String message) {
+        return new DiscordMessage(message);
+    }
+}

--- a/demo/src/main/java/com/example/demo/discord/DiscordMessageProvider.java
+++ b/demo/src/main/java/com/example/demo/discord/DiscordMessageProvider.java
@@ -1,0 +1,31 @@
+package com.example.demo.discord;
+
+import com.example.demo.discord.event.DiscordFeignCustomerService;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.example.demo.discord.DiscordMessage.*;
+
+@Component
+@RequiredArgsConstructor
+public class DiscordMessageProvider {
+
+    private final DiscordFeignCustomerService discordFeignCustomerService;
+
+    public void sendCustomerServiceMessage(String message) {
+        DiscordMessage discordMessage = createCustomerServiceMessage(message);
+        sendCustomerMessageToDiscord(discordMessage);
+    }
+
+    private void sendCustomerMessageToDiscord(DiscordMessage discordMessage) {
+        try {
+            discordFeignCustomerService.sendMessage(discordMessage);
+        } catch (FeignException e) {
+            throw new RuntimeException("ErrorMessage: INVALID_DISCORD_MESSAGE");
+        }
+    }
+
+
+
+}

--- a/demo/src/main/java/com/example/demo/discord/DiscordMessageProvider.java
+++ b/demo/src/main/java/com/example/demo/discord/DiscordMessageProvider.java
@@ -1,11 +1,15 @@
 package com.example.demo.discord;
 
 import com.example.demo.discord.event.DiscordFeignCustomerService;
+import com.example.demo.member.domain.Customer;
+import com.example.demo.member.dto.MypageDTO;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import static com.example.demo.discord.DiscordMessage.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -13,8 +17,32 @@ public class DiscordMessageProvider {
 
     private final DiscordFeignCustomerService discordFeignCustomerService;
 
-    public void sendCustomerServiceMessage(String message) {
-        DiscordMessage discordMessage = createCustomerServiceMessage(message);
+    public void sendCustomerServiceMessage(Customer customer, MypageDTO.CustomerServiceRequest request) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String formattedTimestamp = LocalDateTime.now().format(formatter);
+
+        // Example embed creation
+        DiscordMessage.Embed embed = new DiscordMessage.Embed(
+                request.getTitle(),          // title
+                request.getContent(),        // description
+                4886754,                     // color (Cyan)
+                new DiscordMessage.Footer(formattedTimestamp),
+//                new DiscordMessage.Image("https://example.com/image.png"),
+//                new DiscordMessage.Thumbnail("https://example.com/thumbnail.png"),
+                new DiscordMessage.Author(customer.getName() + "(" +  customer.getUUID() + ")")
+//                List.of(
+//                        new DiscordMessage.Field("Date", "date", true),
+//                        new DiscordMessage.Field("Time", "time", true)
+//                )
+        );
+
+        // Creating a Discord message with the embed
+        DiscordMessage discordMessage = DiscordMessage.createCustomerServiceMessage(
+                EventMessage.CUSTOMER_SERVICE.getMessage(),
+                List.of(embed)
+        );
+
         sendCustomerMessageToDiscord(discordMessage);
     }
 

--- a/demo/src/main/java/com/example/demo/discord/EventMessage.java
+++ b/demo/src/main/java/com/example/demo/discord/EventMessage.java
@@ -1,0 +1,13 @@
+package com.example.demo.discord;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum EventMessage {
+    CUSTOMER_SERVICE("고객센터로 문의가 접수되었습니다.");
+
+    private final String message;
+}

--- a/demo/src/main/java/com/example/demo/discord/event/DiscordFeignCustomerService.java
+++ b/demo/src/main/java/com/example/demo/discord/event/DiscordFeignCustomerService.java
@@ -1,0 +1,13 @@
+package com.example.demo.discord.event;
+
+import com.example.demo.discord.DiscordMessage;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "${discord.customer-service}", url = "${webhooks.customer-service}")
+public interface DiscordFeignCustomerService {
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    void sendMessage(@RequestBody DiscordMessage discordMessage);
+}

--- a/demo/src/main/java/com/example/demo/dummy/DataLoader.java
+++ b/demo/src/main/java/com/example/demo/dummy/DataLoader.java
@@ -135,10 +135,10 @@ public class DataLoader implements CommandLineRunner {
                 .build();
 
         Portfolio portfolio1 = Portfolio.builder()
-                .organization("Organization One")
+                .organization("Forever Weddings")
                 .plannerName("Alice")
                 .region(Region.CHUNGDAM)
-                .introduction("Introduction to Organization One.")
+                .introduction("청담에서 활동하는 Alice입니다")
                 .contactInfo("contact@organizationone.com")
                 .profileImageUrl("portfolio/dummy/7310ef17-c1ea-40e1-a786-aa3ddf82b721.jpg")
                 .consultingFee(100)
@@ -158,7 +158,7 @@ public class DataLoader implements CommandLineRunner {
                 .organization("Organization Two")
                 .plannerName("Bob")
                 .region(Region.GANGNAM)
-                .introduction("Introduction to Organization Two.")
+                .introduction("Yours Weddings")
                 .contactInfo("contact@organizationtwo.com")
                 .profileImageUrl("portfolio/dummy/636300258690471320-jordanharris.jpeg")
                 .consultingFee(200)

--- a/demo/src/main/java/com/example/demo/member/controller/MemberController.java
+++ b/demo/src/main/java/com/example/demo/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.example.demo.member.controller;
 
+import com.example.demo.discord.DiscordMessageProvider;
 import com.example.demo.member.dto.AuthDTO;
 import com.example.demo.member.dto.MypageDTO;
 import com.example.demo.member.service.CustomUserDetailsService;
@@ -34,6 +35,13 @@ public class MemberController {
         MypageDTO.CustomerResponse myPage = customUserDetailsService.getCustomerMyPage();
         log.info("Fetched customer my page");
         return ResponseEntity.status(200).body(myPage);
+    }
+
+    @PostMapping("/mypage/customer/customerservice")
+    @Operation(summary = "[신랑신부] 고객센터 문의", description = "고객센터에 문의합니다.")
+    public ResponseEntity<MypageDTO.CustomerServiceResponse> createCustomerService(@RequestBody MypageDTO.CustomerServiceRequest customerServiceRequest) {
+        MypageDTO.CustomerServiceResponse customerServiceResponse = customUserDetailsService.createCustomerService(customerServiceRequest);
+        return ResponseEntity.status(201).body(customerServiceResponse);
     }
 
     @GetMapping("/mypage/weddingplanner/me")

--- a/demo/src/main/java/com/example/demo/member/dto/MypageDTO.java
+++ b/demo/src/main/java/com/example/demo/member/dto/MypageDTO.java
@@ -84,4 +84,30 @@ public class MypageDTO {
     }
 
 
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CustomerServiceRequest {
+
+        @Schema(type = "string", example = "웨딩플래너 수가 너무 부족해요.")
+        private String content;
+
+    }
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CustomerServiceResponse {
+
+        @Schema(type = "string", example = "고객센터로 문의가 접수되었습니다.")
+        private String content;
+
+    }
+
 }

--- a/demo/src/main/java/com/example/demo/member/dto/MypageDTO.java
+++ b/demo/src/main/java/com/example/demo/member/dto/MypageDTO.java
@@ -92,6 +92,9 @@ public class MypageDTO {
     @Builder
     public static class CustomerServiceRequest {
 
+        @Schema(type = "string", example = "고객센터 문의합니다.")
+        private String title;
+
         @Schema(type = "string", example = "웨딩플래너 수가 너무 부족해요.")
         private String content;
 

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.example.demo.member.service;
 
 import com.example.demo.config.S3Uploader;
+import com.example.demo.discord.DiscordMessageProvider;
 import com.example.demo.enums.member.MemberRole;
 import com.example.demo.member.domain.Customer;
 import com.example.demo.member.domain.CustomerContext;
@@ -42,6 +43,9 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final CustomerMapper customerMapper;
     private final WeddingPlannerMapper weddingPlannerMapper;
     private final S3Uploader s3Uploader;
+
+    private final DiscordMessageProvider discordMessageProvider;
+
 
     @Override
     public UserDetails loadUserByUsername(String UUID) throws UsernameNotFoundException {
@@ -220,5 +224,16 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
         log.info("Found wedding planner with UUID: {}", uuid);
         return weddingPlanner;
+    }
+
+    public MypageDTO.CustomerServiceResponse createCustomerService(MypageDTO.CustomerServiceRequest customerServiceRequest) {
+        discordMessageProvider.sendCustomerServiceMessage(customerServiceRequest.getContent());
+
+        MypageDTO.CustomerServiceResponse response = MypageDTO.CustomerServiceResponse.builder()
+                .content(customerServiceRequest.getContent())
+                .build();
+
+        log.info("Customer service request sent: {}", customerServiceRequest.getContent());
+        return response;
     }
 }

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -1,7 +1,9 @@
 package com.example.demo.member.service;
 
 import com.example.demo.config.S3Uploader;
+import com.example.demo.discord.DiscordMessage;
 import com.example.demo.discord.DiscordMessageProvider;
+import com.example.demo.discord.event.DiscordFeignCustomerService;
 import com.example.demo.enums.member.MemberRole;
 import com.example.demo.member.domain.Customer;
 import com.example.demo.member.domain.CustomerContext;
@@ -45,7 +47,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final S3Uploader s3Uploader;
 
     private final DiscordMessageProvider discordMessageProvider;
-
+    private final DiscordFeignCustomerService discordFeignCustomerService;
 
     @Override
     public UserDetails loadUserByUsername(String UUID) throws UsernameNotFoundException {
@@ -227,13 +229,17 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     public MypageDTO.CustomerServiceResponse createCustomerService(MypageDTO.CustomerServiceRequest customerServiceRequest) {
-        discordMessageProvider.sendCustomerServiceMessage(customerServiceRequest.getContent());
+        Customer customer = getCurrentAuthenticatedCustomer();
+        discordMessageProvider.sendCustomerServiceMessage(customer, customerServiceRequest);
 
         MypageDTO.CustomerServiceResponse response = MypageDTO.CustomerServiceResponse.builder()
                 .content(customerServiceRequest.getContent())
                 .build();
 
         log.info("Customer service request sent: {}", customerServiceRequest.getContent());
+
+
+
         return response;
     }
 }

--- a/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioSearchDTO.java
+++ b/demo/src/main/java/com/example/demo/portfolio/dto/PortfolioSearchDTO.java
@@ -26,6 +26,9 @@ public class PortfolioSearchDTO {
         @Schema(type = "string", example = "김지수")
         private String plannerName;
 
+        @Schema(type = "string", example = "src/wedding_planner/imgs")
+        private String profileImageUrl;
+
         @Schema(type = "string", example = "GANGNAM")
         private String region;
 
@@ -77,6 +80,9 @@ public class PortfolioSearchDTO {
 
         @Schema(type = "string", example = "에바웨딩스")
         private String organization;
+
+        @Schema(type = "string", example = "src/wedding_planner/imgs")
+        private String profileImageUrl;
 
         @Schema(type = "string", example = "김지수")
         private String plannerName;

--- a/demo/src/main/resources/application-prod.yml
+++ b/demo/src/main/resources/application-prod.yml
@@ -47,3 +47,8 @@ management:
   endpoint:
     prometheus:
       enabled: true
+
+discord:
+  customer-service: discord-customer-service
+webhooks:
+  customer-service: ${DISCORD_CUSTOMER_SERVICE}

--- a/demo/src/main/resources/application.yml
+++ b/demo/src/main/resources/application.yml
@@ -60,3 +60,9 @@ management:
   endpoint:
     prometheus:
       enabled: true
+
+
+discord:
+  customer-service: discord-customer-service
+webhooks:
+  customer-service: ${DISCORD_CUSTOMER_SERVICE}


### PR DESCRIPTION
### PR 요약

- 고객센터 메시지 생성 및 Discord 연동 기능 추가

### 변경 사항

- `MemberController`에 고객센터 문의를 처리하는 엔드포인트 추가.
- `CustomUserDetailsService`에 `createCustomerService` 메서드를 구현하여 `DiscordMessageProvider`를 통해 고객센터 메시지를 Discord로 전송.
- `MypageDTO`에 고객센터 요청 및 응답을 처리하는 `CustomerServiceRequest`와 `CustomerServiceResponse` DTO 추가.


### 참고 사항
<img width="402" alt="image" src="https://github.com/user-attachments/assets/8318e034-cff9-4cfb-8d57-93f890f249b8">
