### PR TITLE
Refactor/Change beanstalk recovery time 180 to 300 sec

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,4 +62,4 @@ jobs:
           version_label: github-action-${{ steps.current-time.outputs.formattedTime }} 
           region: ap-northeast-2
           deployment_package: demo/deploy/deploy.zip
-          wait_for_environment_recovery: 180
+          wait_for_environment_recovery: 300


### PR DESCRIPTION
### PR 요약
빈스톡 recovery time 180초에서 300초로 연장
### 변경 사항

### 참고 사항
