### PR TITLE
Feat/Add TimingAspect to log execution time of MessageService methods

### DIFF
--- a/demo/src/main/java/com/example/demo/aspect/TimingAspect.java
+++ b/demo/src/main/java/com/example/demo/aspect/TimingAspect.java
@@ -1,0 +1,24 @@
+package com.example.demo.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class TimingAspect {
+
+    @Around("execution(* com.example.demo.chat.service.MessageService.*(..))")
+    public Object timeMethodExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long timeTaken = System.currentTimeMillis() - startTime;
+
+        System.out.println("--------------------------------------------------------------------------");
+        System.out.println("\n Time taken by " + joinPoint.getSignature() + " is " + timeTaken + " ms\n");
+        System.out.println("--------------------------------------------------------------------------");
+
+        return result;
+    }
+}


### PR DESCRIPTION
### PR 요약
`TimingAspect` 클래스를 추가하여 `MessageService` 메소드의 실행 시간을 측정하고 로그를 남깁니다.

### 변경 사항
- Spring AOP를 사용하여 MessageService의 메소드 실행 시간을 측정하는 TimingAspect 클래스를 도입했습니다.
- 메소드 실행을 감싸고, 소요 시간을 밀리초 단위로 콘솔에 출력합니다.
