### PR TITLE
Refactor/Add reviewerName field to review response

### DIFF
--- a/demo/src/main/java/com/example/demo/dummy/DataLoader.java
+++ b/demo/src/main/java/com/example/demo/dummy/DataLoader.java
@@ -1,11 +1,10 @@
 package com.example.demo.dummy;
 
-import com.example.demo.chat.domain.ChatRoom;
 import com.example.demo.chat.domain.Message;
 import com.example.demo.chat.repository.ChatRoomRepository;
 import com.example.demo.enums.chat.MessageType;
-import com.example.demo.enums.review.RadarKey;
 import com.example.demo.enums.portfolio.Region;
+import com.example.demo.enums.review.RadarKey;
 import com.example.demo.member.domain.Customer;
 import com.example.demo.member.domain.WeddingPlanner;
 import com.example.demo.member.repository.CustomerRepository;
@@ -19,7 +18,6 @@ import com.example.demo.wishlist.repository.WishListRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -276,6 +276,7 @@ public class PortfolioService {
     private ReviewDTO.Response mapToReviewResponse(Review review) {
         return ReviewDTO.Response.builder()
                 .id(review.getId())
+                .reviewerName(review.getReviewerName())
                 .portfolioId(review.getPortfolio().getId())
                 .rating(review.getRating())
                 .estimate(review.getEstimate())

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -5,11 +5,11 @@ import com.example.demo.enums.review.RadarKey;
 import com.example.demo.member.domain.WeddingPlanner;
 import com.example.demo.member.mapper.WeddingPlannerMapper;
 import com.example.demo.member.service.CustomUserDetailsService;
+import com.example.demo.portfolio.domain.Portfolio;
+import com.example.demo.portfolio.dto.PortfolioDTO;
 import com.example.demo.portfolio.dto.PortfolioOverviewDTO;
 import com.example.demo.portfolio.mapper.PortfolioMapper;
 import com.example.demo.portfolio.repository.PortfolioRepository;
-import com.example.demo.portfolio.domain.Portfolio;
-import com.example.demo.portfolio.dto.PortfolioDTO;
 import com.example.demo.review.domain.Review;
 import com.example.demo.review.dto.ReviewDTO;
 import com.example.demo.review.repository.ReviewRepository;
@@ -63,7 +63,9 @@ public class PortfolioService {
 
     public List<ReviewDTO.Response> getReviewsByPortfolioId(Long portfolioId) {
         log.info("Starting getReviewsByPortfolioId method for portfolio ID: {}", portfolioId);
-        return reviewRepository.findByPortfolioId(portfolioId).stream()
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow();
+        return reviewRepository.findByPortfolio(portfolio).stream()
                 .map(this::mapToReviewResponse)
                 .collect(Collectors.toList());
     }
@@ -111,7 +113,7 @@ public class PortfolioService {
 
 
         String profileImagePresigendUrl = "";
-        if(portfolioRequest.getProfileImageUrl() != null && !portfolioRequest.getProfileImageUrl().equals(existingPortfolio.getProfileImageUrl())) {
+        if (portfolioRequest.getProfileImageUrl() != null && !portfolioRequest.getProfileImageUrl().equals(existingPortfolio.getProfileImageUrl())) {
             //Delete existing image from s3 and upload new image
             s3Uploader.deleteFile(existingPortfolio.getProfileImageUrl());
             existingPortfolio.setProfileImageUrl(s3Uploader.makeUniqueFileName("portfolio", portfolioId, portfolioRequest.getProfileImageUrl()));

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -284,6 +284,7 @@ public class PortfolioService {
                 .content(review.getContent())
                 .createdAt(review.getCreatedAt())
                 .updatedAt(review.getUpdatedAt())
+                .weddingPhotoUrls(review.getWeddingPhotoUrls())
                 .build();
     }
 

--- a/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
+++ b/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
@@ -45,7 +45,7 @@ public class ReviewDTO {
 
         @Schema(type = "object", example = "{\"COMMUNICATION\": 4.5, \"BUDGET_COMPLIANCE\": 3.8, \"PERSONAL_CUSTOMIZATION\": 4.7, \"PRICE_RATIONALITY\": 4.0, \"SCHEDULE_COMPLIANCE\": 4.6}")
         private Map<RadarKey, Float> radar;
-        
+
         @Schema(type = "integer", example = "2")
         private Long portfolioId;
 
@@ -89,22 +89,12 @@ public class ReviewDTO {
         @Schema(type = "object", example = "{\"COMMUNICATION\": 4.5, \"BUDGET_COMPLIANCE\": 3.8, \"PERSONAL_CUSTOMIZATION\": 4.7, \"PRICE_RATIONALITY\": 4.0, \"SCHEDULE_COMPLIANCE\": 4.6}")
         private Map<RadarKey, Float> radar;
 
-        @Schema(type = "array", example = "[\"https://s3.amazonaws.com/bucket/weddingPhoto1.jpg\", \"https://s3.amazonaws.com/bucket/weddingPhoto2.jpg\"]", description = "각각 10분동안 유효하며, 보낸 이미지 순서대로 presigned URL이 반환됩니다.")
-        private List<String> presignedWeddingPhotoUrls;
-
         @Schema(type = "LocalDateTime", example = "2024-07-04 16:53:33.130731")
         private LocalDateTime createdAt;
 
         @Schema(type = "LocalDateTime", example = "2024-07-04 16:53:33.130731")
         private LocalDateTime updatedAt;
-
-
-        public List<String> getPresignedWeddingPhotoUrls() {
-            if (this.presignedWeddingPhotoUrls == null) {
-                this.presignedWeddingPhotoUrls = new ArrayList<>();
-            }
-            return this.presignedWeddingPhotoUrls;
-        }
+        
 
         public List<String> getWeddingPhotoUrls() {
             if (this.weddingPhotoUrls == null) {

--- a/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
+++ b/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
@@ -86,6 +86,9 @@ public class ReviewDTO {
         @Schema(type = "array", example = "[\"src/portfolio/23/img1.jpg\", \"src/portfolio/23/img2.jpg\"]")
         private List<String> weddingPhotoUrls;
 
+        @Schema(type = "array", example = "[\"https://s3.amazonaws.com/bucket/weddingPhoto1.jpg\", \"https://s3.amazonaws.com/bucket/weddingPhoto2.jpg\"]", description = "각각 10분동안 유효하며, 보낸 이미지 순서대로 presigned URL이 반환됩니다.")
+        private List<String> presignedWeddingPhotoUrls;
+
         @Schema(type = "object", example = "{\"COMMUNICATION\": 4.5, \"BUDGET_COMPLIANCE\": 3.8, \"PERSONAL_CUSTOMIZATION\": 4.7, \"PRICE_RATIONALITY\": 4.0, \"SCHEDULE_COMPLIANCE\": 4.6}")
         private Map<RadarKey, Float> radar;
 
@@ -95,6 +98,12 @@ public class ReviewDTO {
         @Schema(type = "LocalDateTime", example = "2024-07-04 16:53:33.130731")
         private LocalDateTime updatedAt;
         
+        public List<String> getPresignedWeddingPhotoUrls() {
+            if (this.presignedWeddingPhotoUrls == null) {
+                this.presignedWeddingPhotoUrls = new ArrayList<>();
+            }
+            return this.presignedWeddingPhotoUrls;
+        }
 
         public List<String> getWeddingPhotoUrls() {
             if (this.weddingPhotoUrls == null) {

--- a/demo/src/main/java/com/example/demo/review/repository/ReviewRepository.java
+++ b/demo/src/main/java/com/example/demo/review/repository/ReviewRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    List<Review> findByPortfolioId(Long portfolioId);
+    List<Review> findByPortfolio(Portfolio portfolio);
 
     @Transactional
     @Modifying

--- a/demo/src/main/java/com/example/demo/review/repository/ReviewRepository.java
+++ b/demo/src/main/java/com/example/demo/review/repository/ReviewRepository.java
@@ -21,13 +21,13 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query(value = "UPDATE Review r SET r.isDeleted = true WHERE r.id = :id")
     void softDeleteById(@Param("id") Long id);
 
-    @Query(value = "SELECT * from Review r WHERE r.is_deleted = true", nativeQuery = true)
+    @Query("SELECT r from Review r WHERE r.isDeleted = true")
     List<Review> findSoftDeletedReviews();
 
-    @Query(value = "SELECT * from Review r WHERE r.is_provided = true and r.reviewer_id = :weddingPlannerId", nativeQuery = true)
+    @Query("SELECT r from Review r WHERE r.isProvided = true and r.reviewerId = :weddingPlannerId")
     List<Review> findReviewsForWeddingPlanner(Long weddingPlannerId);
 
-    @Query(value = "SELECT * from Review r WHERE r.is_provided = false and r.reviewer_id = :customerId", nativeQuery = true)
+    @Query("SELECT r from Review r WHERE r.isProvided = false and r.reviewerId = :customerId")
     List<Review> findReviewsForCustomer(Long customerId);
 
     Integer countByPortfolioId(Long id);

--- a/demo/src/main/java/com/example/demo/review/service/ReviewService.java
+++ b/demo/src/main/java/com/example/demo/review/service/ReviewService.java
@@ -69,13 +69,12 @@ public class ReviewService {
         Portfolio portfolio = portfolioService.reflectNewReview(reviewRequest);
         review.setPortfolio(portfolio);
         review.setReviewerId(weddingPlanner.getId());
-        review.setReviewerName("사용자"+weddingPlanner.getName().substring(0, 3));
+        review.setReviewerName("사용자" + weddingPlanner.getName().substring(0, 3));
         review.setIsProvided(true);
 
         reviewRepository.save(review);
 
         ReviewDTO.Response response = reviewMapper.entityToResponse(review);
-        response.setPresignedWeddingPhotoUrls(presignedUrlList);
 
         log.info("Successfully created review for wedding planner with ID: {}", review.getId());
         return response;
@@ -89,7 +88,7 @@ public class ReviewService {
         //일단 id를 가져오기 위한 save
         Review review = reviewRepository.save(reviewMapper.requestToEntity(reviewRequest));
 
-        //review/{id}/uuid 형식으로 이미지명 생성
+        //review/{reviewId}/uuid 형식으로 이미지명 생성
         review.setWeddingPhotoUrls(
                 reviewRequest.getWeddingPhotoUrls().stream()
                         .map(url -> s3Uploader.makeUniqueFileName("review", review.getId(), url))
@@ -106,7 +105,7 @@ public class ReviewService {
         reviewRepository.save(review);
 
         ReviewDTO.Response response = reviewMapper.entityToResponse(review);
-        response.setPresignedWeddingPhotoUrls(presignedUrlList);
+        response.setPortfolioId(portfolio.getId());
 
         log.info("Successfully created review for customer with ID: {}", review.getId());
         return response;
@@ -120,7 +119,7 @@ public class ReviewService {
         Review existingReview = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new RuntimeException("Review not found"));
 
-        if (!existingReview.getReviewerId().equals(weddingPlanner.getId())){
+        if (!existingReview.getReviewerId().equals(weddingPlanner.getId())) {
             log.error("Unauthorized attempt to modify review with ID: {}", reviewId);
             throw new RuntimeException("Not authorized to modify this review");
         }
@@ -153,7 +152,6 @@ public class ReviewService {
         Review updatedReview = reviewRepository.save(existingReview);
 
         ReviewDTO.Response response = reviewMapper.entityToResponse(updatedReview);
-        response.setPresignedWeddingPhotoUrls(weddingPhotosPresignedUrlList);
 
         log.info("Successfully modified review for wedding planner with ID: {}", reviewId);
         return response;
@@ -203,7 +201,6 @@ public class ReviewService {
         Review updatedReview = reviewRepository.save(existingReview);
 
         ReviewDTO.Response response = reviewMapper.entityToResponse(updatedReview);
-        response.setPresignedWeddingPhotoUrls(weddingPhotosPresignedUrlList);
 
         log.info("Successfully modified review for customer with ID: {}", reviewId);
         return response;

--- a/demo/src/main/java/com/example/demo/review/service/ReviewService.java
+++ b/demo/src/main/java/com/example/demo/review/service/ReviewService.java
@@ -75,6 +75,8 @@ public class ReviewService {
         reviewRepository.save(review);
 
         ReviewDTO.Response response = reviewMapper.entityToResponse(review);
+        response.setPortfolioId(portfolio.getId());
+        response.setPresignedWeddingPhotoUrls(presignedUrlList);
 
         log.info("Successfully created review for wedding planner with ID: {}", review.getId());
         return response;
@@ -106,6 +108,7 @@ public class ReviewService {
 
         ReviewDTO.Response response = reviewMapper.entityToResponse(review);
         response.setPortfolioId(portfolio.getId());
+        response.setPresignedWeddingPhotoUrls(presignedUrlList);
 
         log.info("Successfully created review for customer with ID: {}", review.getId());
         return response;
@@ -152,6 +155,9 @@ public class ReviewService {
         Review updatedReview = reviewRepository.save(existingReview);
 
         ReviewDTO.Response response = reviewMapper.entityToResponse(updatedReview);
+        response.setPortfolioId(portfolio.getId());
+        response.setPresignedWeddingPhotoUrls(weddingPhotosPresignedUrlList);
+
 
         log.info("Successfully modified review for wedding planner with ID: {}", reviewId);
         return response;
@@ -201,6 +207,9 @@ public class ReviewService {
         Review updatedReview = reviewRepository.save(existingReview);
 
         ReviewDTO.Response response = reviewMapper.entityToResponse(updatedReview);
+        response.setPortfolioId(portfolio.getId());
+        response.setPresignedWeddingPhotoUrls(weddingPhotosPresignedUrlList);
+
 
         log.info("Successfully modified review for customer with ID: {}", reviewId);
         return response;


### PR DESCRIPTION
### PR 요약

리뷰 응답에 `reviewerName` 필드 추가 및 `findByPortfolioId` 메소드 리팩토링

### 변경 사항
- PortfolioService의 mapToReviewResponse 메소드에 reviewerName 필드를 추가하여 리뷰어의 이름을 응답 DTO에 포함시킴.
- PortfolioService에서 Portfolio 객체를 ID로 조회한 후 리뷰를 가져오도록 수정.
- ReviewRepository의 findByPortfolioId 메소드를 findByPortfolio로 리팩토링하여 portfolioId 대신 Portfolio 객체를 인수로 받도록 변경.
- PortfolioService의 import 구문을 변경된 로직에 맞게 조정.
- PortfolioService의 일부 포맷팅 문제를 수정.

### 참고 사항
