### PR TITLE
Refactor/Update reviewer name handling and remove reviewerName from ReviewDTO.Request

### DIFF
--- a/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
+++ b/demo/src/main/java/com/example/demo/portfolio/controller/PortfolioController.java
@@ -37,7 +37,7 @@ public class PortfolioController {
     public ResponseEntity<PortfolioDTO.Response> getPortfolioById(
             @Parameter(description = "portfolioId")
             @PathVariable Long portfolioId) {
-        if (customUserDetailsService.getCurrentAuthenticatedMemberRole().equals(CUSTOMER)){
+        if (customUserDetailsService.getCurrentAuthenticatedMemberRole().equals(CUSTOMER)) {
             portfolioService.increaseViewCount(portfolioId);
         }
         PortfolioDTO.Response portfolioResponse = portfolioService.getPortfolioById(portfolioId);
@@ -85,8 +85,8 @@ public class PortfolioController {
 
     @GetMapping("/shared/soft-deleted")
     @Operation(summary = "[공통] soft-deleted가 된 포트폴리오 조회")
-    public ResponseEntity<List<PortfolioDTO.Response>> getAllSoftDeleted() {
-        List<PortfolioDTO.Response> softDeletedPortfolios = portfolioService.getAllSoftDeletedPortfolios();
+    public ResponseEntity<List<PortfolioOverviewDTO.Response>> getAllSoftDeleted() {
+        List<PortfolioOverviewDTO.Response> softDeletedPortfolios = portfolioService.getAllSoftDeletedPortfolios();
         log.info("Fetched all soft-deleted portfolios");
         return ResponseEntity.ok(softDeletedPortfolios);
     }

--- a/demo/src/main/java/com/example/demo/portfolio/mapper/PortfolioMapper.java
+++ b/demo/src/main/java/com/example/demo/portfolio/mapper/PortfolioMapper.java
@@ -4,11 +4,7 @@ import com.example.demo.portfolio.domain.Portfolio;
 import com.example.demo.portfolio.dto.PortfolioDTO;
 import com.example.demo.portfolio.dto.PortfolioOverviewDTO;
 import com.example.demo.portfolio.dto.PortfolioSearchDTO;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "spring")
@@ -19,7 +15,7 @@ public interface PortfolioMapper {
     Portfolio requestToEntity(PortfolioDTO.Request portfolioRequest);
 
     PortfolioDTO.Response entityToResponse(Portfolio portfolio);
-
+    
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "id", ignore = true)
     Portfolio updateFromRequest(PortfolioDTO.Request portfolioRequest, @MappingTarget Portfolio portfolio);

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -174,10 +174,10 @@ public class PortfolioService {
         log.info("Deleted portfolio with ID: {}", portfolioId);
     }
 
-    public List<PortfolioDTO.Response> getAllSoftDeletedPortfolios() {
+    public List<PortfolioOverviewDTO.Response> getAllSoftDeletedPortfolios() {
         log.info("Starting getAllSoftDeletedPortfolios method");
         return portfolioRepository.findSoftDeletedPortfolios().stream()
-                .map(portfolioMapper::entityToResponse)
+                .map(portfolioMapper::entityToOverviewResponse)
                 .collect(Collectors.toList());
     }
 

--- a/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
+++ b/demo/src/main/java/com/example/demo/review/dto/ReviewDTO.java
@@ -20,9 +20,6 @@ public class ReviewDTO {
     public static class Request {
 
         @Schema(type = "string", example = "name1")
-        private String reviewerName;
-
-        @Schema(type = "string", example = "name1")
         private String content;
 
         @Schema(type = "boolean", example = "true")
@@ -97,7 +94,7 @@ public class ReviewDTO {
 
         @Schema(type = "LocalDateTime", example = "2024-07-04 16:53:33.130731")
         private LocalDateTime updatedAt;
-        
+
         public List<String> getPresignedWeddingPhotoUrls() {
             if (this.presignedWeddingPhotoUrls == null) {
                 this.presignedWeddingPhotoUrls = new ArrayList<>();

--- a/demo/src/main/java/com/example/demo/review/service/ReviewService.java
+++ b/demo/src/main/java/com/example/demo/review/service/ReviewService.java
@@ -69,7 +69,7 @@ public class ReviewService {
         Portfolio portfolio = portfolioService.reflectNewReview(reviewRequest);
         review.setPortfolio(portfolio);
         review.setReviewerId(weddingPlanner.getId());
-        review.setReviewerName("사용자" + weddingPlanner.getName().substring(0, 3));
+        review.setReviewerName(weddingPlanner.getName());
         review.setIsProvided(true);
 
         reviewRepository.save(review);
@@ -100,6 +100,7 @@ public class ReviewService {
         List<String> presignedUrlList = s3Uploader.getPresignedUrls(review.getWeddingPhotoUrls());
 
         Portfolio portfolio = portfolioService.reflectNewReview(reviewRequest);
+        review.setReviewerName(customer.getName());
         review.setPortfolio(portfolio);
         review.setReviewerId(customer.getId());
         review.setIsProvided(false);


### PR DESCRIPTION
### PR 요약
ReviewDTO.Request에서 reviewerName 필드를 제거하고, 리뷰 생성 시 리뷰어 이름 설정 방식을 변경했습니다.

### 변경 사항
- 리뷰 작성 및 조회 시, request에서 유저 정보 가져오던 방식에서 context에서 유저 정보 조회하여 정보 등록
- `/api/v1/portfolio/shared/all` API 요청에 대한 reponse를 Overview 형태로 통일
- `ReviewDTO.Request` 클래스에서 `reviewerName` 필드 삭제.
- `ReviewService` 클래스에서 리뷰어 이름을 하드코딩된 Prefix 대신 WeddingPlanner 및 Customer 엔티티의 이름을 사용하여 직접 설정하도록 수정.
### 참고 사항
