### PR TITLE
Test/ChatRepository Test 

### DIFF
--- a/demo/src/test/java/com/example/demo/chat/repository/ChatRoomRepositoryTest.java
+++ b/demo/src/test/java/com/example/demo/chat/repository/ChatRoomRepositoryTest.java
@@ -116,5 +116,33 @@ class ChatRoomRepositoryTest {
         assertThat(findChatRoom.getCustomer().getId()).isEqualTo(customer.getId());
     }
 
-   
+    @Test
+    @DisplayName("고객 ID로 마지막 메세지가 생성된 순서로 채팅방을 조회한다.")
+    void findByCustomerIdOrderByLastMessageCreatedAtDesc() {
+        // given
+        Customer customer = Customer.builder()
+                .id(1L)
+                .build();
+
+        ChatRoom chatRoom1 = ChatRoom.builder()
+                .customer(customer)
+                .build();
+
+        ChatRoom chatRoom2 = ChatRoom.builder()
+                .customer(customer)
+                .build();
+
+        customerRepository.save(customer);
+        chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2));
+
+        // when
+        List<ChatRoom> chatRooms = chatRoomRepository.findByCustomerIdOrderByLastMessageCreatedAtDesc(customer.getId());
+
+        // then
+        assertThat(chatRooms.size()).isEqualTo(2);
+        assertThat(chatRooms.get(0).getCustomer().getId()).isEqualTo(customer.getId());
+        assertThat(chatRooms.get(1).getCustomer().getId()).isEqualTo(customer.getId());
+    }
+
+    
 }

--- a/demo/src/test/java/com/example/demo/chat/repository/ChatRoomRepositoryTest.java
+++ b/demo/src/test/java/com/example/demo/chat/repository/ChatRoomRepositoryTest.java
@@ -5,6 +5,8 @@ import com.example.demo.config.S3Uploader;
 import com.example.demo.member.domain.Customer;
 import com.example.demo.member.domain.WeddingPlanner;
 import com.example.demo.member.repository.CustomerRepository;
+import com.example.demo.member.repository.WeddingPlannerRepository;
+import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +35,8 @@ class ChatRoomRepositoryTest {
 
     @Autowired
     private CustomerRepository customerRepository;
+    @Autowired
+    private WeddingPlannerRepository weddingPlannerRepository;
 
     @Test
     @DisplayName("고객 ID로 채팅방을 조회한다.")
@@ -126,11 +131,15 @@ class ChatRoomRepositoryTest {
 
         ChatRoom chatRoom1 = ChatRoom.builder()
                 .customer(customer)
+                .lastMessageCreatedAt(LocalDateTime.parse("2000-01-01T00:00:00"))
                 .build();
 
         ChatRoom chatRoom2 = ChatRoom.builder()
                 .customer(customer)
+                .lastMessageCreatedAt(LocalDateTime.parse("2000-01-02T00:00:00"))
                 .build();
+
+        customer.setChatRooms(List.of(chatRoom1, chatRoom2));
 
         customerRepository.save(customer);
         chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2));
@@ -140,9 +149,46 @@ class ChatRoomRepositoryTest {
 
         // then
         assertThat(chatRooms.size()).isEqualTo(2);
-        assertThat(chatRooms.get(0).getCustomer().getId()).isEqualTo(customer.getId());
-        assertThat(chatRooms.get(1).getCustomer().getId()).isEqualTo(customer.getId());
+
+        // compare chatRoom1 and chatRoom2
+        assertThat(chatRooms.get(0).getLastMessageCreatedAt())
+                .isAfter(chatRooms.get(1).getLastMessageCreatedAt()); // chatRoom2 should be first because it's more recent
+
     }
 
-    
+    @Test
+    @Transactional
+    @DisplayName("웨딩플래너 ID로 마지막 메세지가 생성된 순서로 채팅방을 조회한다.")
+    void findByWeddingPlannerIdOrderByLastMessageCreatedAtDesc() {
+        // given
+        WeddingPlanner weddingPlanner = WeddingPlanner.builder()
+                .id(1L)
+                .build();
+
+        ChatRoom chatRoom1 = ChatRoom.builder()
+                .weddingPlanner(weddingPlanner)
+                .lastMessageCreatedAt(LocalDateTime.parse("2000-01-01T00:00:00"))
+                .build();
+
+        ChatRoom chatRoom2 = ChatRoom.builder()
+                .weddingPlanner(weddingPlanner)
+                .lastMessageCreatedAt(LocalDateTime.parse("2000-01-02T00:00:00"))
+                .build();
+
+        weddingPlanner.setChatRooms(List.of(chatRoom1, chatRoom2));
+
+        weddingPlannerRepository.save(weddingPlanner);
+        chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2));
+
+        // when
+        List<ChatRoom> chatRooms = chatRoomRepository.findByWeddingPlannerIdOrderByLastMessageCreatedAtDesc(weddingPlanner.getId());
+
+        // then
+        assertThat(chatRooms.size()).isEqualTo(2);
+
+        // compare chatRoom1 and chatRoom2
+        assertThat(chatRooms.get(0).getLastMessageCreatedAt())
+                .isAfter(chatRooms.get(1).getLastMessageCreatedAt()); // chatRoom2 should be first because it's more recent
+    }
+
 }

--- a/demo/src/test/java/com/example/demo/chat/repository/ChatRoomRepositoryTest.java
+++ b/demo/src/test/java/com/example/demo/chat/repository/ChatRoomRepositoryTest.java
@@ -65,5 +65,33 @@ class ChatRoomRepositoryTest {
         assertThat(chatRooms.get(1).getCustomer().getId()).isEqualTo(customer.getId());
     }
 
+    @Test
+    @DisplayName("웨딩플래너 ID로 채팅방을 조회한다.")
+    void findByWeddingPlannerId() {
+        // given
+        Customer customer = Customer.builder()
+                .id(1L)
+                .build();
 
+        ChatRoom chatRoom1 = ChatRoom.builder()
+                .customer(customer)
+                .build();
+
+        ChatRoom chatRoom2 = ChatRoom.builder()
+                .customer(customer)
+                .build();
+
+        customerRepository.save(customer);
+        chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2));
+
+        // when
+        List<ChatRoom> chatRooms = chatRoomRepository.findByCustomerId(customer.getId());
+
+        // then
+        assertThat(chatRooms.size()).isEqualTo(2);
+        assertThat(chatRooms.get(0).getCustomer().getId()).isEqualTo(customer.getId());
+        assertThat(chatRooms.get(1).getCustomer().getId()).isEqualTo(customer.getId());
+    }
+
+   
 }

--- a/demo/src/test/java/com/example/demo/chat/repository/ChatRoomRepositoryTest.java
+++ b/demo/src/test/java/com/example/demo/chat/repository/ChatRoomRepositoryTest.java
@@ -3,9 +3,8 @@ package com.example.demo.chat.repository;
 import com.example.demo.chat.domain.ChatRoom;
 import com.example.demo.config.S3Uploader;
 import com.example.demo.member.domain.Customer;
+import com.example.demo.member.domain.WeddingPlanner;
 import com.example.demo.member.repository.CustomerRepository;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,9 +32,6 @@ class ChatRoomRepositoryTest {
 
     @Autowired
     private CustomerRepository customerRepository;
-
-    @PersistenceContext
-    private EntityManager entityManager;
 
     @Test
     @DisplayName("고객 ID로 채팅방을 조회한다.")
@@ -91,6 +87,33 @@ class ChatRoomRepositoryTest {
         assertThat(chatRooms.size()).isEqualTo(2);
         assertThat(chatRooms.get(0).getCustomer().getId()).isEqualTo(customer.getId());
         assertThat(chatRooms.get(1).getCustomer().getId()).isEqualTo(customer.getId());
+    }
+
+    @Test
+    @DisplayName("고객 ID와 웨딩플래너 ID로 채팅방을 조회한다.")
+    void findByCustomerIdAndWeddingPlannerId() {
+        // given
+        Customer customer = Customer.builder()
+                .id(1L)
+                .build();
+
+        WeddingPlanner weddingPlanner = WeddingPlanner.builder()
+                .id(1L)
+                .build();
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .customer(customer)
+                .weddingPlanner(weddingPlanner)
+                .build();
+
+        customerRepository.save(customer);
+        chatRoomRepository.save(chatRoom);
+
+        // when
+        ChatRoom findChatRoom = chatRoomRepository.findByCustomerIdAndWeddingPlannerId(customer.getId(), weddingPlanner.getId());
+
+        // then
+        assertThat(findChatRoom.getCustomer().getId()).isEqualTo(customer.getId());
     }
 
    

--- a/demo/src/test/java/com/example/demo/chat/repository/MessageRepositoryTest.java
+++ b/demo/src/test/java/com/example/demo/chat/repository/MessageRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.example.demo.chat.repository;
+
+import com.example.demo.chat.domain.ChatRoom;
+import com.example.demo.chat.domain.Message;
+import com.example.demo.config.S3Uploader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static com.example.demo.enums.member.MemberRole.CUSTOMER;
+import static com.example.demo.enums.member.MemberRole.WEDDING_PLANNER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MessageRepositoryTest {
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @MockBean
+    private S3Uploader s3Uploader;
+
+    @Autowired
+    private MessageRepository messageRepository;
+
+    @Test
+    @DisplayName("읽지 않은 상대방의 메세지 개수를 조회한다")
+    void countUnreadMessages() {
+        // given
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .build();
+
+        Message message1 = Message.builder()
+                .chatRoom(chatRoom)
+                .senderRole(CUSTOMER)
+                .oppositeReadFlag(false)
+                .build();
+
+        Message message2 = Message.builder()
+                .chatRoom(chatRoom)
+                .senderRole(CUSTOMER)
+                .oppositeReadFlag(true)
+                .build();
+
+        Message message3 = Message.builder()
+                .chatRoom(chatRoom)
+                .senderRole(WEDDING_PLANNER)
+                .oppositeReadFlag(false)
+                .build();
+
+        Message message4 = Message.builder()
+                .chatRoom(chatRoom)
+                .senderRole(WEDDING_PLANNER)
+                .oppositeReadFlag(true)
+                .build();
+
+        chatRoomRepository.save(chatRoom);
+        messageRepository.saveAll(List.of(message1, message2, message3, message4));
+
+        // when
+        int unreadMessageCount = messageRepository.countUnreadMessages(chatRoom.getId(), CUSTOMER);
+
+        // then
+        assertThat(unreadMessageCount).isEqualTo(1);
+    }
+
+}


### PR DESCRIPTION
### PR 요약
`ChatRoomRepository`에 대한 테스트 코드


### 변경 사항
- 기존 `읽지 않은 상대방의 메세지 개수를 조회한다` 작업은 `MessageRepository`에 적합하다고 생각하여 메서드 및 테스트 move
- test: 고객 ID로 채팅방을 조회한다
- test: 웨딩플레너 ID로 채팅방을 조회한다
- test: 고객 ID와 웨딩플래너 ID로 채팅방을 조회한다
- test: 고객 ID로 마지막 메세지가 생성된 순서로 채팅방을 조회한다
- test: 웨딩플래너 ID로 마지막 메세지가 생성된 순서로 채팅방을 조회한다

### 참고 사항
