### PR TITLE
Test/Jacoco Code Coverage

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -153,7 +153,6 @@ jacocoTestCoverageVerification {
 
             // 라인 커버리지 설정
             // 적용 대상 전체 소스 코드들을 한줄 한줄 따졌을 때 테스트 코드가 작성되어 있는 줄의 빈도
-            // 테스트 코드가 작성되어 있는 비율이 90% 이상이어야 함
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
@@ -162,7 +161,6 @@ jacocoTestCoverageVerification {
 
             // 브랜치 커버리지 설정
             // if-else 등을 활용하여 발생되는 분기들 중 테스트 코드가 작성되어 있는 빈도
-            // 테스트 코드가 작성되어 있는 비율이 90% 이상이어야 함
             limit {
                 counter = 'BRANCH'
                 value = 'COVEREDRATIO'

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.0'
     id 'io.spring.dependency-management' version '1.1.5'
+    id 'jacoco'
 }
 
 group = 'com.example'
@@ -99,7 +100,7 @@ dependencies {
     // 	discord
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.1'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-    
+
 }
 
 tasks.named('test') {
@@ -113,4 +114,69 @@ configurations {
 
 jar {
     enabled = false
+}
+
+
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy 'jacocoTestReport' // test가 끝나면 jacocoTestReport 동작
+}
+
+// jacoco report 설정
+jacocoTestReport {
+    // 커버리지 보고서 제외 범위 설정
+    getClassDirectories().setFrom(
+            files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: [
+                        '**/dto',
+                        '**/base',
+                ])
+            })
+    )
+
+    reports {
+        // html로 report 생성하기
+        // 빌드경로/jacoco/report.html 폴더 내부로 경로 설정
+        html.destination file("$buildDir/jacoco/report.html")
+    }
+
+    // jacocoTestReport가 끝나면 jacocoTestCoverageVerification 동작
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+// jacoco 커버리지 검증 설정
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true // 커버리지 적용 여부
+            element = 'CLASS' // 커버리지 적용 단위
+
+            // 라인 커버리지 설정
+            // 적용 대상 전체 소스 코드들을 한줄 한줄 따졌을 때 테스트 코드가 작성되어 있는 줄의 빈도
+            // 테스트 코드가 작성되어 있는 비율이 90% 이상이어야 함
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            // 브랜치 커버리지 설정
+            // if-else 등을 활용하여 발생되는 분기들 중 테스트 코드가 작성되어 있는 빈도
+            // 테스트 코드가 작성되어 있는 비율이 90% 이상이어야 함
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            // 라인 최대 갯수 설정
+            // 빈 줄을 제외하고 하나의 자바 파일에서 작성될 수 있는 최대 라인 갯수
+            // 한 파일에 최대 500줄까지 작성되어야 함
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 500
+            }
+        }
+    }
 }

--- a/demo/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/demo/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,14 +1,17 @@
 package com.example.demo;
 
+import com.example.demo.config.S3Uploader;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-//@SpringBootTest
+@SpringBootTest
+@ActiveProfiles("test")
 class DemoApplicationTests {
+
+    @MockBean
+    private S3Uploader s3Uploader;
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
### PR 요약
JaCoCo 코드 커버리지

### 변경 사항
- JaCoCo 코드 커버리지 관련 의존성 추가
- test : 프로그램 실행 시 context load에 대한 테스트

### 참고 사항
![image](https://github.com/user-attachments/assets/dc29846a-f418-4619-a542-7828236eae6c)

현재 설정은 아래와 같습니다.
- 라인 커버리지 80% 이상일 때 통과
- 분기 커버러지 80% 이상일 때 통과
- 파일 당 최대 라인 500 줄 이하인지 검사