### PR TITLE
Feat/Kakao OAuth2 Login & Join

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+
 //  json parsing
     implementation 'com.google.code.gson:gson:2.9.0'
 
@@ -58,14 +59,13 @@ dependencies {
     implementation("org.mapstruct:mapstruct:1.5.3.Final")
     implementation("org.projectlombok:lombok-mapstruct-binding:0.2.0")
 
-
 //  security
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation group: 'org.javassist', name: 'javassist', version: '3.15.0-GA'
 
-    //AWS SDK for Java 1.x
+    // AWS SDK for Java 1.x
     implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.529')
     implementation 'com.amazonaws:aws-java-sdk-s3'
 
@@ -73,19 +73,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 
-    //jwt & security
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    // security
     implementation("org.springframework.boot:spring-boot-starter-security")
 
-    //TestDB
+    // TestDB
     testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
 
-    //Aws Opensearch
+    // Aws Opensearch
     implementation("org.opensearch.client:opensearch-rest-client:2.11.0")
     implementation("org.opensearch.client:opensearch-java:2.7.0")
     implementation("jakarta.json:jakarta.json-api")
 
-    //swagger
+    // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
     // log4j2
@@ -105,7 +104,8 @@ dependencies {
     // oauth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-
+    // netty-resolver
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 }
 
 tasks.named('test') {

--- a/demo/src/main/java/com/example/demo/admin/controller/AdminController.java
+++ b/demo/src/main/java/com/example/demo/admin/controller/AdminController.java
@@ -1,0 +1,32 @@
+package com.example.demo.admin.controller;
+
+import com.example.demo.admin.dto.AdminDTO;
+import com.example.demo.admin.service.AdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@Slf4j
+@RequestMapping("/api/v1/admin")
+@Tag(name = "admin", description = "관리자 API")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping("/member/all")
+    @Operation(summary = "모든 회원 조회")
+    public ResponseEntity<List<AdminDTO.MemberResponse>> getAllMembers() {
+        List<AdminDTO.MemberResponse> allMembers = adminService.getAllMembers();
+        log.info("Fetched all members");
+        return ResponseEntity.status(200).body(allMembers);
+    }
+}

--- a/demo/src/main/java/com/example/demo/admin/dto/AdminDTO.java
+++ b/demo/src/main/java/com/example/demo/admin/dto/AdminDTO.java
@@ -1,0 +1,25 @@
+package com.example.demo.admin.dto;
+
+import com.example.demo.enums.member.MemberRole;
+import lombok.*;
+
+public class AdminDTO {
+
+    @Getter
+    @Setter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MemberResponse {
+        private Long id;
+
+        private MemberRole role;
+
+        private String name;
+
+        private String UUID;
+    }
+
+
+}

--- a/demo/src/main/java/com/example/demo/admin/service/AdminService.java
+++ b/demo/src/main/java/com/example/demo/admin/service/AdminService.java
@@ -1,0 +1,57 @@
+package com.example.demo.admin.service;
+
+import com.example.demo.admin.dto.AdminDTO;
+import com.example.demo.enums.member.MemberRole;
+import com.example.demo.member.domain.Customer;
+import com.example.demo.member.domain.WeddingPlanner;
+import com.example.demo.member.repository.CustomerRepository;
+import com.example.demo.member.repository.WeddingPlannerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminService {
+
+    private final CustomerRepository customerRepository;
+    private final WeddingPlannerRepository weddingPlannerRepository;
+
+    public List<AdminDTO.MemberResponse> getAllMembers() {
+        List<Customer> customers = customerRepository.findAll();
+        List<WeddingPlanner> weddingPlanners = weddingPlannerRepository.findAll();
+
+        // Map customers to MemberResponse
+        List<AdminDTO.MemberResponse> customerResponses = customers.stream()
+                .map(customer -> AdminDTO.MemberResponse.builder()
+                        .id(customer.getId())
+                        .role(MemberRole.CUSTOMER)  // Assuming role is set like this
+                        .name(customer.getName())
+                        .UUID(customer.getUUID())   // Assuming Customer has a getUUID method
+                        .build())
+                .collect(Collectors.toList());
+
+        // Map wedding planners to MemberResponse
+        List<AdminDTO.MemberResponse> weddingPlannerResponses = weddingPlanners.stream()
+                .map(weddingPlanner -> AdminDTO.MemberResponse.builder()
+                        .id(weddingPlanner.getId())
+                        .role(MemberRole.WEDDING_PLANNER)  // Assuming role is set like this
+                        .name(weddingPlanner.getName())
+                        .UUID(weddingPlanner.getUUID())    // Assuming WeddingPlanner has a getUUID method
+                        .build())
+                .collect(Collectors.toList());
+
+        // Combine both lists
+        List<AdminDTO.MemberResponse> allMembers = new ArrayList<>();
+        allMembers.addAll(customerResponses);
+        allMembers.addAll(weddingPlannerResponses);
+
+        return allMembers;
+    }
+}
+

--- a/demo/src/main/java/com/example/demo/config/S3Uploader.java
+++ b/demo/src/main/java/com/example/demo/config/S3Uploader.java
@@ -29,7 +29,6 @@ public class S3Uploader {
     private String cloudfrontPath;
 
     private final int PRESIGNED_URL_EXPIRATION = 60 * 1000 * 10; // 10분
-    
 
 
     // Upload file to S3 using presigned url
@@ -45,7 +44,7 @@ public class S3Uploader {
         return url;
     }
 
-    private Date setExpiration(){
+    private Date setExpiration() {
         Date expiration = new Date();
         long expTimeMillis = expiration.getTime();
         expTimeMillis += PRESIGNED_URL_EXPIRATION;
@@ -54,31 +53,31 @@ public class S3Uploader {
     }
 
     public String makeUniqueFileName(String type, Long id, String fileName) {
-        return type + "/" + id +"/" + UUID.randomUUID() + "." + getFileExtension(fileName);
+        return type + "/" + id + "/" + UUID.randomUUID() + "." + getFileExtension(fileName);
     }
 
-    public static String getFileExtension(String fileName) throws RuntimeException{
+    public static String getFileExtension(String fileName) throws RuntimeException {
         if (fileName == null || fileName.lastIndexOf('.') == -1) {
             throw new RuntimeException("파일 확장자가 없습니다.");
         }
         return fileName.substring(fileName.lastIndexOf('.') + 1);
     }
 
-    public void deleteFile(String fileName){
+    public void deleteFile(String fileName) {
         if (fileName == null) {
             return;
         }
-        if (checkFileExists(fileName)){
+        if (checkFileExists(fileName)) {
             s3Config.amazonS3().deleteObject(new DeleteObjectRequest(bucket, fileName));
         }
     }
 
 
-    public String getPresignedUrl(String fileName){
+    public String getPresignedUrl(String fileName) {
         return generatePresignedUrl(fileName).toString();
     }
 
-    public List<String> getPresignedUrls(List<String> fileNameList){
+    public List<String> getPresignedUrls(List<String> fileNameList) {
         List<String> presignedUrlList = new ArrayList<>();
         for (String fileName : fileNameList) {
             presignedUrlList.add(generatePresignedUrl(fileName).toString());

--- a/demo/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -15,7 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity(debug = false)
-public class SecurityConfig{
+public class SecurityConfig {
 
     @Autowired
     private JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -26,25 +26,33 @@ public class SecurityConfig{
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-            .csrf(AbstractHttpConfigurer::disable)
-            .authorizeHttpRequests(authorize -> authorize
-                    .requestMatchers("/api/v1/auth/shared/create").permitAll()
-                    .requestMatchers("/", "/index.html","/weddingplanner-chat.html","/customer-chat.html", "/swagger-ui/*",  "/swagger-resources/**", "/v3/api-docs/**", "/actuator/**", "/metrics/**").permitAll()
-                    .requestMatchers("/api/v1/*/shared/**").hasAnyRole("CUSTOMER","WEDDING_PLANNER")
-                    .requestMatchers("/api/v1/*/weddingplanner/**").hasRole("WEDDING_PLANNER")
-                    .requestMatchers("/api/v1/*/customer/**").hasRole("CUSTOMER")
-                    .requestMatchers("/stomp/**").permitAll()
-                    .anyRequest().authenticated()
-            );
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                                .requestMatchers("/**").permitAll() // wildcard
+                                .requestMatchers("/api/v1/auth/shared/create").permitAll()
+                                .requestMatchers("/", "/index.html", "/weddingplanner-chat.html", "/customer-chat.html", "/swagger-ui/*", "/swagger-resources/**", "/v3/api-docs/**", "/actuator/**", "/metrics/**").permitAll()
+                                .requestMatchers("/api/v1/*/shared/**").hasAnyRole("CUSTOMER", "WEDDING_PLANNER")
+                                .requestMatchers("/api/v1/*/weddingplanner/**").hasRole("WEDDING_PLANNER")
+                                .requestMatchers("/api/v1/*/customer/**").hasRole("CUSTOMER")
+                                .requestMatchers("/stomp/**").permitAll()
+                                .requestMatchers("/kakao.html", "/login.html").permitAll()
+                                .anyRequest().authenticated()
+//                )
+//                .oauth2Login(ouath2 -> ouath2
+//                        .loginPage("/kakao")
+//                        .defaultSuccessUrl("/home", true)
+//                        .failureUrl("/login?error=true")
+//                        .permitAll()
+                );
         return http.build();
     }
 
     @Bean
     public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
         http
-            .getSharedObject(AuthenticationManagerBuilder.class)
-            .userDetailsService(customUserDetailsService);
+                .getSharedObject(AuthenticationManagerBuilder.class)
+                .userDetailsService(customUserDetailsService);
         return http.getSharedObject(AuthenticationManager.class);
     }
 }

--- a/demo/src/main/java/com/example/demo/enums/member/MemberRole.java
+++ b/demo/src/main/java/com/example/demo/enums/member/MemberRole.java
@@ -2,7 +2,8 @@ package com.example.demo.enums.member;
 
 public enum MemberRole {
     WEDDING_PLANNER,
-    CUSTOMER;
+    CUSTOMER,
+    UNKNOWN;
 
     public String getRoleName() {
         return this.name();

--- a/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
+++ b/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
@@ -1,0 +1,160 @@
+package com.example.demo.jwt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider implements InitializingBean {
+    private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
+
+    private static final long ACCESS_TOKEN_VALIDITY_SECONDS_TEST = 60; // 테스트용 AT는 1분
+    private static final long REFRESH_TOKEN_VALIDITY_SECONDS_TEST = 10; // 테스트용 RT는 1분
+    private static final long ACCESS_TOKEN_VALIDITY_SECONDS = 24 * 60 * 60; // access token은 24시간
+    private static final long REFRESH_TOKEN_VALIDITY_SECONDS = 24 * 60 * 60 * 14; // refresh token은 2주일
+
+    private Key key;
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String getUsername(String token) {
+        try {
+            key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+            Claims claims = Jwts.parser()
+                    .setSigningKey(key)
+                    .parseClaimsJws(token)
+                    .getBody();
+            System.out.println("claims.getSubject() = " + claims.getSubject());
+            return claims.getSubject();
+        } catch (SignatureException ex) {
+            logger.error("Invalid JWT signature");
+        } catch (MalformedJwtException ex) {
+            logger.error("Invalid JWT token");
+        } catch (ExpiredJwtException ex) {
+            logger.error("Expired JWT token");
+        } catch (UnsupportedJwtException ex) {
+            logger.error("Unsupported JWT token");
+        } catch (IllegalArgumentException ex) {
+            logger.error("JWT claims string is empty.");
+        }
+        return null;
+    }
+
+    public String getAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && StringUtils.startsWithIgnoreCase(bearerToken, "Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        // 쿠키에서 토큰 추출
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("accessToken".equals(cookie.getName())) {
+                    System.out.println("cookie.getName() = " + cookie.getName());
+                    System.out.println("cookie.getValue() = " + cookie.getValue());
+                    return cookie.getValue();
+                }
+            }
+        }
+        throw new RuntimeException("No AccessToken Found");
+    }
+
+    public String getUniqueId(String accessToken) {
+        Claims claims = Jwts.parser().setSigningKey(key).parseClaimsJws(accessToken).getBody();
+        return claims.get("uniqueId", String.class);
+    }
+
+    public String createRefreshToken(String username, String uniqueId) {
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + REFRESH_TOKEN_VALIDITY_SECONDS * 1000);
+
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("uniqueId", uniqueId) // 커스텀 클레임으로 uniqueId 추가
+                .signWith(key, SignatureAlgorithm.HS512)
+                .setExpiration(validity)
+                .compact();
+    }
+
+    public String createAccessToken(String username, String uniqueId) {
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + ACCESS_TOKEN_VALIDITY_SECONDS * 1000);
+
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("uniqueId", uniqueId) // 커스텀 클레임으로 uniqueId 추가
+                .signWith(key, SignatureAlgorithm.HS512)
+                .setExpiration(validity)
+                .compact();
+    }
+
+    public String getTokenUserId(String token) {
+        Claims claims = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody();
+        return claims.getSubject();
+    }
+
+//    public Authentication getAuthentication(String token) {
+//        UserDetails userDetails = userDetailsService.loadUserByUsername(getUniqueId(token));
+//        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+//    }
+
+    public boolean validateAccessToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(key).parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            logger.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    public long getRefreshTokenExpiration(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(key)
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getExpiration().getTime() - System.currentTimeMillis();
+    }
+
+    public long getRefreshTokenExpirationByManual(String token) throws JsonProcessingException {
+        String[] parts = token.split("\\.");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("Invalid JWT token format");
+        }
+        String payload = new String(Base64.getDecoder().decode(parts[1]));
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode claimsNode = objectMapper.readTree(payload);
+        long expirationTime = claimsNode.get("exp").asLong() * 1000;
+        return expirationTime - System.currentTimeMillis();
+    }
+}

--- a/demo/src/main/java/com/example/demo/jwt/handler/JwtAuthenticationFilter.java
+++ b/demo/src/main/java/com/example/demo/jwt/handler/JwtAuthenticationFilter.java
@@ -1,0 +1,11 @@
+package com.example.demo.jwt.handler;
+
+import com.example.demo.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final TokenProvider tokenProvider;
+}

--- a/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
+++ b/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
@@ -1,0 +1,113 @@
+package com.example.demo.jwt.handler;
+
+import com.example.demo.jwt.TokenProvider;
+import com.example.demo.member.service.CustomUserDetailsService;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    private final TokenProvider tokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    private static final List<String> WHITELIST = Arrays.asList(
+            "/api/v1/member/reissue"
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest servletRequest,
+                                    HttpServletResponse servletResponse,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String requestURI = servletRequest.getRequestURI();
+
+        // 화이트리스트에 포함된 요청은 필터를 통과시키지 않고 계속 진행
+        if (WHITELIST.contains(requestURI)) {
+            System.out.println("requestURI = " + requestURI);
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
+        try {
+            String jwt = resolveToken(servletRequest);
+            //만약 토큰에 이상이 있다면 오류가 발생한다.
+            if (StringUtils.hasText(jwt) && tokenProvider.validateAccessToken(jwt)) {
+                //tokenProvider에서 jwt를 가져가 Authentication 객체생성
+                Authentication authentication = customUserDetailsService.getAuthentication(jwt);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            //이상이 없다면 계속 진행
+            filterChain.doFilter(servletRequest, servletResponse);
+        } catch (JwtException e) {
+            //토큰에 오류가 있다면 401에러를 응답한다.
+            log.error("[JWTExceptionHandlerFilter] " + e.getMessage());
+            servletResponse.setStatus(401);
+            servletResponse.setContentType("application/json;charset=UTF-8");
+        }
+    }
+
+    private void handleAuthenticationException(HttpServletResponse response, AuthenticationException ex) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"Unauthorized - " + ex.getMessage() + "\"}");
+    }
+
+    private void handleOtherExceptions(HttpServletResponse response, Exception ex) throws IOException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"Error processing request - " + ex.getMessage() + "\"}");
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        // 헤더에서 토큰 추출
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && StringUtils.startsWithIgnoreCase(bearerToken, "Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        // 쿠키에서 토큰 추출
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    // 인증 처리
+    public void setAuthentication(String username) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String uniqueId) {
+        System.out.println("username hihi = " + uniqueId);
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(uniqueId);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/demo/src/main/java/com/example/demo/member/controller/MemberController.java
+++ b/demo/src/main/java/com/example/demo/member/controller/MemberController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/member")
 @Tag(name = "member", description = "멤버 API")
 @Slf4j
 public class MemberController {

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.example.demo.member.service;
 import com.example.demo.config.S3Uploader;
 import com.example.demo.discord.DiscordMessageProvider;
 import com.example.demo.enums.member.MemberRole;
+import com.example.demo.jwt.TokenProvider;
 import com.example.demo.member.domain.Customer;
 import com.example.demo.member.domain.CustomerContext;
 import com.example.demo.member.domain.WeddingPlanner;
@@ -13,9 +14,12 @@ import com.example.demo.member.mapper.CustomerMapper;
 import com.example.demo.member.mapper.WeddingPlannerMapper;
 import com.example.demo.member.repository.CustomerRepository;
 import com.example.demo.member.repository.WeddingPlannerRepository;
+import com.example.demo.oauth2.kakao.dto.KakaoUserInfoResponseDto;
+import com.example.demo.oauth2.kakao.dto.LoginDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -31,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.example.demo.enums.member.MemberRole.CUSTOMER;
 import static com.example.demo.enums.member.MemberRole.WEDDING_PLANNER;
 
 @Service
@@ -45,6 +50,8 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final S3Uploader s3Uploader;
 
     private final DiscordMessageProvider discordMessageProvider;
+
+    private final TokenProvider tokenProvider;
 
     @Override
     public UserDetails loadUserByUsername(String UUID) throws UsernameNotFoundException {
@@ -96,6 +103,53 @@ public class CustomUserDetailsService implements UserDetailsService {
             throw new IllegalArgumentException("Invalid role type");
         }
     }
+
+    @Transactional
+    public LoginDTO.Response createKakaoMember(KakaoUserInfoResponseDto userInfoResponseDto, String role) {
+        String username = userInfoResponseDto.kakaoAccount.profile.nickName;
+        String UUID = "kakao-" + userInfoResponseDto.id;
+
+        String accessToken = tokenProvider.createAccessToken(username, UUID);
+        String refreshToken = tokenProvider.createRefreshToken(username, UUID);
+
+        Optional<Customer> findCustomer = customerRepository.findByUUID(UUID);
+        Optional<WeddingPlanner> findWeddingPlanner = weddingPlannerRepository.findByUUID(UUID);
+
+        if (findCustomer.isPresent()) {
+            Customer existCustomer = findCustomer.get();
+            existCustomer.updateRefreshToken(refreshToken);
+        } else if (findWeddingPlanner.isPresent()) {
+            WeddingPlanner existWeddingPlanner = findWeddingPlanner.get();
+            existWeddingPlanner.updateRefreshToken(refreshToken);
+        } else if (role.equals(CUSTOMER.getRoleName())) {
+            Customer customer = Customer.builder()
+                    .role(MemberRole.CUSTOMER)
+                    .name(userInfoResponseDto.kakaoAccount.profile.nickName)
+//                    .email(userInfoResponseDto.kakaoAccount.email)
+                    .UUID(UUID)
+//                    .profileImage(userInfoResponseDto.kakaoAccount.profile.profileImageUrl)
+                    .refreshToken(refreshToken)
+                    .build();
+
+            customerRepository.save(customer);
+        } else if (role.equals(WEDDING_PLANNER.getRoleName())) {
+            WeddingPlanner weddingPlanner = WeddingPlanner.builder()
+                    .role(WEDDING_PLANNER)
+                    .name(userInfoResponseDto.kakaoAccount.profile.nickName)
+                    .UUID(UUID)
+                    .refreshToken(refreshToken)
+                    .build();
+
+            weddingPlannerRepository.save(weddingPlanner);
+        }
+
+        return LoginDTO.Response.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .UUID(UUID)
+                .build();
+    }
+
 
     public Customer getCurrentAuthenticatedCustomer() throws UsernameNotFoundException {
         log.info("Getting current authenticated customer");
@@ -263,5 +317,10 @@ public class CustomUserDetailsService implements UserDetailsService {
         log.info("Customer service request sent: {}", customerServiceRequest.getContent());
 
         return response;
+    }
+
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = loadUserByUsername(tokenProvider.getUniqueId(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 }

--- a/demo/src/main/java/com/example/demo/oauth2/kakao/controller/Oauth2Controller.java
+++ b/demo/src/main/java/com/example/demo/oauth2/kakao/controller/Oauth2Controller.java
@@ -1,0 +1,37 @@
+package com.example.demo.oauth2.kakao.controller;
+
+import com.example.demo.member.service.CustomUserDetailsService;
+import com.example.demo.oauth2.kakao.dto.KakaoUserInfoResponseDto;
+import com.example.demo.oauth2.kakao.dto.LoginDTO;
+import com.example.demo.oauth2.kakao.service.KakaoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/oauth2")
+@Tag(name = "oauth2", description = "OAuth2 로그인 API")
+public class Oauth2Controller {
+
+    private final KakaoService kakaoService;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @PostMapping("/shared/kakao")
+    @Operation(summary = "[공통] 카카오 로그인")
+    public ResponseEntity<LoginDTO.Response> kakaoLogin(@RequestBody LoginDTO.Request loginRequest) {
+        String kakaoAccessToken = kakaoService.getAccessTokenFromKakaoDev(loginRequest.getCode());
+        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(kakaoAccessToken);
+        String role = loginRequest.getRole();
+
+        LoginDTO.Response loginResponse = customUserDetailsService.createKakaoMember(userInfo, role);
+        return ResponseEntity.status(200).body(loginResponse);
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/kakao/dto/KakaoTokenResponseDto.java
+++ b/demo/src/main/java/com/example/demo/oauth2/kakao/dto/KakaoTokenResponseDto.java
@@ -1,0 +1,33 @@
+package com.example.demo.oauth2.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponseDto {
+
+    @JsonProperty("token_type")
+    public String tokenType;
+
+    @JsonProperty("access_token")
+    public String accessToken;
+
+    @JsonProperty("id_token")
+    public String idToken;
+
+    @JsonProperty("expires_in")
+    public Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    public Integer refreshTokenExpiresIn;
+    
+    @JsonProperty("scope")
+    public String scope;
+}

--- a/demo/src/main/java/com/example/demo/oauth2/kakao/dto/KakaoUserInfoResponseDto.java
+++ b/demo/src/main/java/com/example/demo/oauth2/kakao/dto/KakaoUserInfoResponseDto.java
@@ -1,0 +1,190 @@
+package com.example.demo.oauth2.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.HashMap;
+
+@Getter
+@NoArgsConstructor //역직렬화를 위한 기본 생성자
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponseDto {
+
+    //회원 번호
+    @JsonProperty("id")
+    public Long id;
+
+    //자동 연결 설정을 비활성화한 경우만 존재.
+    //true : 연결 상태, false : 연결 대기 상태
+    @JsonProperty("has_signed_up")
+    public Boolean hasSignedUp;
+
+    //서비스에 연결 완료된 시각. UTC
+    @JsonProperty("connected_at")
+    public Date connectedAt;
+
+    //카카오싱크 간편가입을 통해 로그인한 시각. UTC
+    @JsonProperty("synched_at")
+    public Date synchedAt;
+
+    //사용자 프로퍼티
+    @JsonProperty("properties")
+    public HashMap<String, String> properties;
+
+    //카카오 계정 정보
+    @JsonProperty("kakao_account")
+    public KakaoAccount kakaoAccount;
+
+    //uuid 등 추가 정보
+    @JsonProperty("for_partner")
+    public Partner partner;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoAccount {
+
+        //프로필 정보 제공 동의 여부
+        @JsonProperty("profile_needs_agreement")
+        public Boolean isProfileAgree;
+
+        //닉네임 제공 동의 여부
+        @JsonProperty("profile_nickname_needs_agreement")
+        public Boolean isNickNameAgree;
+
+        //프로필 사진 제공 동의 여부
+        @JsonProperty("profile_image_needs_agreement")
+        public Boolean isProfileImageAgree;
+
+        //사용자 프로필 정보
+        @JsonProperty("profile")
+        public Profile profile;
+
+        //이름 제공 동의 여부
+        @JsonProperty("name_needs_agreement")
+        public Boolean isNameAgree;
+
+        //카카오계정 이름
+        @JsonProperty("name")
+        public String name;
+
+        //이메일 제공 동의 여부
+        @JsonProperty("email_needs_agreement")
+        public Boolean isEmailAgree;
+
+        //이메일이 유효 여부
+        // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
+        @JsonProperty("is_email_valid")
+        public Boolean isEmailValid;
+
+        //이메일이 인증 여부
+        //true : 인증된 이메일, false : 인증되지 않은 이메일
+        @JsonProperty("is_email_verified")
+        public Boolean isEmailVerified;
+
+        //카카오계정 대표 이메일
+        @JsonProperty("email")
+        public String email;
+
+        //연령대 제공 동의 여부
+        @JsonProperty("age_range_needs_agreement")
+        public Boolean isAgeAgree;
+
+        //연령대
+        //참고 https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+        @JsonProperty("age_range")
+        public String ageRange;
+
+        //출생 연도 제공 동의 여부
+        @JsonProperty("birthyear_needs_agreement")
+        public Boolean isBirthYearAgree;
+
+        //출생 연도 (YYYY 형식)
+        @JsonProperty("birthyear")
+        public String birthYear;
+
+        //생일 제공 동의 여부
+        @JsonProperty("birthday_needs_agreement")
+        public Boolean isBirthDayAgree;
+
+        //생일 (MMDD 형식)
+        @JsonProperty("birthday")
+        public String birthDay;
+
+        //생일 타입
+        // SOLAR(양력) 혹은 LUNAR(음력)
+        @JsonProperty("birthday_type")
+        public String birthDayType;
+
+        //성별 제공 동의 여부
+        @JsonProperty("gender_needs_agreement")
+        public Boolean isGenderAgree;
+
+        //성별
+        @JsonProperty("gender")
+        public String gender;
+
+        //전화번호 제공 동의 여부
+        @JsonProperty("phone_number_needs_agreement")
+        public Boolean isPhoneNumberAgree;
+
+        //전화번호
+        //국내 번호인 경우 +82 00-0000-0000 형식
+        @JsonProperty("phone_number")
+        public String phoneNumber;
+
+        //CI 동의 여부
+        @JsonProperty("ci_needs_agreement")
+        public Boolean isCIAgree;
+
+        //CI, 연계 정보
+        @JsonProperty("ci")
+        public String ci;
+
+        //CI 발급 시각, UTC
+        @JsonProperty("ci_authenticated_at")
+        public Date ciCreatedAt;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public class Profile {
+
+            //닉네임
+            @JsonProperty("nickname")
+            public String nickName;
+
+            //프로필 미리보기 이미지 URL
+            @JsonProperty("thumbnail_image_url")
+            public String thumbnailImageUrl;
+
+            //프로필 사진 URL
+            @JsonProperty("profile_image_url")
+            public String profileImageUrl;
+
+            //프로필 사진 URL 기본 프로필인지 여부
+            //true : 기본 프로필, false : 사용자 등록
+            @JsonProperty("is_default_image")
+            public String isDefaultImage;
+
+            //닉네임이 기본 닉네임인지 여부
+            //true : 기본 닉네임, false : 사용자 등록
+            @JsonProperty("is_default_nickname")
+            public Boolean isDefaultNickName;
+
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class Partner {
+        //고유 ID
+        @JsonProperty("uuid")
+        public String uuid;
+    }
+
+}

--- a/demo/src/main/java/com/example/demo/oauth2/kakao/dto/LoginAccessTokenResponseDto.java
+++ b/demo/src/main/java/com/example/demo/oauth2/kakao/dto/LoginAccessTokenResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.demo.oauth2.kakao.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginAccessTokenResponseDto {
+    private String accessToken;
+
+    private String refreshToken;
+
+    private String UUID;
+}

--- a/demo/src/main/java/com/example/demo/oauth2/kakao/dto/LoginDTO.java
+++ b/demo/src/main/java/com/example/demo/oauth2/kakao/dto/LoginDTO.java
@@ -1,0 +1,40 @@
+package com.example.demo.oauth2.kakao.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class LoginDTO {
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String code;
+
+        @Schema(type = "string", example = "WEDDING_PLANNER")
+        private String role;
+    }
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String accessToken;
+
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String refreshToken;
+
+        @Schema(type = "string", example = "kakao-asdd2d12d")
+        private String UUID;
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/kakao/dto/LoginMemberResponseDto.java
+++ b/demo/src/main/java/com/example/demo/oauth2/kakao/dto/LoginMemberResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.demo.oauth2.kakao.dto;
+
+import com.example.demo.enums.member.MemberRole;
+import com.example.demo.member.domain.Customer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginMemberResponseDto {
+
+    private String name;
+
+    private String uniqueId;
+
+    private String refreshToken;
+
+    private String accessToken;
+
+    private MemberRole memberRole;
+
+    // Static factory method
+    public static LoginMemberResponseDto fromCustomer(Customer customer, String accessToken) {
+        return new LoginMemberResponseDto(
+                customer.getName(),
+                customer.getUUID(),
+                accessToken, customer.getRefreshToken(),
+                customer.getRole()
+        );
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/kakao/service/KakaoService.java
+++ b/demo/src/main/java/com/example/demo/oauth2/kakao/service/KakaoService.java
@@ -1,0 +1,111 @@
+package com.example.demo.oauth2.kakao.service;
+
+import com.example.demo.oauth2.kakao.dto.KakaoTokenResponseDto;
+import com.example.demo.oauth2.kakao.dto.KakaoUserInfoResponseDto;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+public class KakaoService {
+
+    private String clientIdTest = "1d91a9b555e1b5d32675dcb7d2192a7c";
+    private String clientSecretTest = "HjIvutqsy0OYQQAYqx9XpWPzR211dnd7";
+    private String clientId;
+    private String clientSecret;
+    private final String KAUTH_TOKEN_URL_HOST;
+    private final String KAUTH_USER_URL_HOST;
+
+    @Autowired
+    public KakaoService(@Value("${kakao.client_id_web}") String clientId,
+                        @Value("${kakao.client_secret_web}") String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com";
+        KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+    }
+
+    public String getAccessTokenFromKakaoDev(String code) {
+        KakaoTokenResponseDto kakaoTokenResponseDto = WebClient.create(KAUTH_TOKEN_URL_HOST).post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/oauth/token")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", clientIdTest)
+                        .queryParam("client_secret", clientSecretTest)
+                        .queryParam("code", code)
+                        .queryParam("redirect_uri", "http://localhost:8080/login/oauth2/code/kakao")
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("400 Invalid Parameter " + clientResponse.toString())))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("500 Internal Server Error")))
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .block();
+
+
+        log.info(" [ Kakao Service ] Access Token ------> {}", kakaoTokenResponseDto.getAccessToken());
+        log.info(" [ Kakao Service ] Refresh Token ------> {}", kakaoTokenResponseDto.getRefreshToken());
+        log.info(" [ Kakao Service ] Scope ------> {}", kakaoTokenResponseDto.getScope());
+
+        return kakaoTokenResponseDto.getAccessToken();
+    }
+
+    public String getAccessTokenFromKakaoDeploy(String code) {
+        KakaoTokenResponseDto kakaoTokenResponseDto = WebClient.create(KAUTH_TOKEN_URL_HOST)
+                .post()
+                .uri("/oauth/token")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .body(BodyInserters.fromFormData("grant_type", "authorization_code")
+                        .with("client_id", clientId)
+                        .with("client_secret", clientSecret)
+                        .with("code", code)
+                        // TODO : redirect_uri HTTPS 설정 후 도메인 변경
+                        .with("redirect_uri", "http://dears-core-server.ap-northeast-2.elasticbeanstalk.com//login/oauth2/code/kakao"))
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("KAKAO Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("500 Internal Server Error")))
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .block();
+
+        log.info(" [ Kakao Service ] Access Token ------> {}", kakaoTokenResponseDto.getAccessToken());
+        log.info(" [ Kakao Service ] Refresh Token ------> {}", kakaoTokenResponseDto.getRefreshToken());
+        log.info(" [ Kakao Service ] Scope ------> {}", kakaoTokenResponseDto.getScope());
+
+        return kakaoTokenResponseDto.getAccessToken();
+    }
+
+    public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
+
+        KakaoUserInfoResponseDto userInfo = WebClient.create(KAUTH_USER_URL_HOST)
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/v2/user/me")
+                        .build(true))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .bodyToMono(KakaoUserInfoResponseDto.class)
+                .block();
+
+        log.info(" [ Kakao Service ] Auth ID ---> {} ", userInfo.getId());
+        log.info(" [ Kakao Service ] NickName ---> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
+        log.info(" [ Kakao Service ] ProfileImageUrl ---> {} ", userInfo.getKakaoAccount().getProfile().getProfileImageUrl());
+
+        return userInfo;
+    }
+
+}

--- a/demo/src/main/resources/application.yml
+++ b/demo/src/main/resources/application.yml
@@ -91,9 +91,15 @@ management:
       enabled: true
 
 kakao:
-  client_id: ${KAKAO_CLIENT_ID_WEB}
-  client_secret: ${KAKAO_SECRET_ID_WEB}
-  
+  client_id_web: ${KAKAO_CLIENT_ID_WEB}
+  client_secret_web: ${KAKAO_SECRET_ID_WEB}
+  client_id_native: ${KAKAO_CLIENT_ID_NATIVE}
+
+jwt:
+  header: Authorization
+  #HS512 알고리즘을 사용할 것이기 때문에 512bit,  즉 64byte 이상의 secret key를 사용해야 한다.
+  secret: ${JWT_SECRET}
+  token-validity-in-seconds: 86400 # ttl (초)
 ---
 spring:
   config:

--- a/demo/src/main/resources/static/kakao.html
+++ b/demo/src/main/resources/static/kakao.html
@@ -5,6 +5,6 @@
     <title>kakao-login</title>
 </head>
 <body>
-<a href="https://kauth.kakao.com/oauth/authorize?client_id=1d91a9b555e1b5d32675dcb7d2192a7c&response_type=code&redirect_uri=http://localhost:8080/login/oauth2/code/kakao">login</a>
+<a href="https://kauth.kakao.com/oauth/authorize?client_id=1d91a9b555e1b5d32675dcb7d2192a7c&response_type=code&redirect_uri=http://localhost:8080/login/oauth2/code/kakao&prompt=login">login</a>
 </body>
 </html>


### PR DESCRIPTION
### PR 요약
카카오 OAuth2 소셜 로그인 구현

### 변경 사항
- `jwt provider`에서 kakao code 이용하여 토큰 발행

### 참고 사항
- `/**` 와일드카드로 루트 뚫어두었습니다. 추후 로그인 필터링하지 않게 세분화 필요
- 추후 로그인과 회원가입에 대한 분리 필요(현재는 로그인만 구현하여 회원가입과 동일한 역할)

![image](https://github.com/user-attachments/assets/124b38f0-39da-4c74-bc8f-782c111f8585)
해당 사진의 3~7번 과정이 구현되어 있습니다.