### PR TITLE
Feat/Reissue access & refresh token by refresh token

### DIFF
--- a/demo/src/main/java/com/example/demo/error/ErrorCode.java
+++ b/demo/src/main/java/com/example/demo/error/ErrorCode.java
@@ -79,7 +79,10 @@ public enum ErrorCode {
     FEIGN_CLIENT_ERROR(400, "G013", "Feign Client Error Exception"),
 
     // UsernameNotFoundException
-    USERNAME_NOT_FOUND_ERROR(404, "G014", "Username Not Found Exception");
+    USERNAME_NOT_FOUND_ERROR(404, "G014", "Username Not Found Exception"),
+
+    // token expired
+    REFRESH_TOKEN_EXPIRED_ERROR(401, "G015", "Refresh Token Expired Exception");
 
     /**
      * ******************************* Error Code Constructor ***************************************

--- a/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
+++ b/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import javax.security.auth.RefreshFailedException;
 import java.io.IOException;
 
 @Slf4j
@@ -165,6 +166,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(JsonParseException.class)
     protected ResponseEntity<ErrorResponse> handleJsonParseExceptionException(JsonParseException ex) {
         return buildErrorResponseAndSendAlert(ex, ErrorCode.JSON_PARSE_ERROR, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * @param ex RefreshFailedException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(RefreshFailedException.class)
+    protected ResponseEntity<ErrorResponse> handleRefreshFailedException(RefreshFailedException ex) {
+        return buildErrorResponseAndSendAlert(ex, ErrorCode.REFRESH_TOKEN_EXPIRED_ERROR, HttpStatus.BAD_REQUEST);
     }
 
     /**

--- a/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
+++ b/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
@@ -117,9 +117,25 @@ public class TokenProvider implements InitializingBean {
         return claims.getSubject();
     }
 
-    public boolean validateAccessToken(String token) {
+    public boolean validateAccessToken(String accessToken) {
         try {
-            Jwts.parser().setSigningKey(key).parseClaimsJws(token);
+            Jwts.parser().setSigningKey(key).parseClaimsJws(accessToken);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            logger.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            Jwts.parser().setSigningKey(key).parseClaimsJws(refreshToken);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             logger.info("잘못된 JWT 서명입니다.");

--- a/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
+++ b/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
@@ -117,11 +117,6 @@ public class TokenProvider implements InitializingBean {
         return claims.getSubject();
     }
 
-//    public Authentication getAuthentication(String token) {
-//        UserDetails userDetails = userDetailsService.loadUserByUsername(getUniqueId(token));
-//        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-//    }
-
     public boolean validateAccessToken(String token) {
         try {
             Jwts.parser().setSigningKey(key).parseClaimsJws(token);

--- a/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
+++ b/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
@@ -32,7 +32,7 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
     private final CustomUserDetailsService customUserDetailsService;
 
     private static final List<String> WHITELIST = Arrays.asList(
-            "/api/v1/member/reissue"
+            "/api/v1/oauth2/shared/reissue"
     );
 
     @Override

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -240,18 +240,14 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     public Customer getCustomerByUuid(String uuid) {
         log.info("Getting customer by UUID: {}", uuid);
-        Customer customer = customerRepository.findByUUID(uuid)
+        return customerRepository.findByUUID(uuid)
                 .orElseThrow(() -> new RuntimeException("Customer not found"));
-        log.info("Found customer with UUID: {}", uuid);
-        return customer;
     }
 
     public WeddingPlanner getWeddingPlannerByUuid(String uuid) {
         log.info("Getting wedding planner by UUID: {}", uuid);
-        WeddingPlanner weddingPlanner = weddingPlannerRepository.findByUUID(uuid)
+        return weddingPlannerRepository.findByUUID(uuid)
                 .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
-        log.info("Found wedding planner with UUID: {}", uuid);
-        return weddingPlanner;
     }
 
     public MypageDTO.CustomerServiceResponse createCustomerService(MypageDTO.CustomerServiceRequest customerServiceRequest) {

--- a/demo/src/main/java/com/example/demo/member/service/MemberRegistryService.java
+++ b/demo/src/main/java/com/example/demo/member/service/MemberRegistryService.java
@@ -30,6 +30,7 @@ public class MemberRegistryService {
     @Transactional
     public KakaoLoginDTO.Response createKakaoMember(KakaoUserInfoResponseDTO userInfoResponseDto, String role) {
         String username = userInfoResponseDto.kakaoAccount.profile.nickName;
+
         String UUID = generateUUID("kakao", userInfoResponseDto.id.toString());
 
         // Generate access and refresh tokens
@@ -45,6 +46,35 @@ public class MemberRegistryService {
 
         return buildKakaoLoginResponse(UUID, accessToken, refreshToken);
     }
+
+    @Transactional
+    public KakaoLoginDTO.Response createTestMember(KakaoUserInfoResponseDTO userInfoResponseDto, String role) {
+        String username;
+        Long id;
+        if (userInfoResponseDto == null) {
+            username = "test";
+            id = 1L;
+        } else {
+            username = userInfoResponseDto.kakaoAccount.profile.nickName;
+            id = userInfoResponseDto.id;
+        }
+
+        String UUID = "51fc7d6b-7f86-43cf-b5c7-de4c46046d71";
+
+        // Generate access and refresh tokens
+        String accessToken = tokenProvider.createAccessToken(username, UUID);
+        String refreshToken = tokenProvider.createRefreshToken(username, UUID);
+
+        // Delegate customer or wedding planner handling based on role
+        if (role.equals(MemberRole.CUSTOMER.getRoleName())) {
+            processCustomer(UUID, username, refreshToken);
+        } else if (role.equals(MemberRole.WEDDING_PLANNER.getRoleName())) {
+            processWeddingPlanner(UUID, username, refreshToken);
+        }
+
+        return buildKakaoLoginResponse(UUID, accessToken, refreshToken);
+    }
+
 
     @Transactional
     public GoogleLoginDTO.Response createGoogleMember(GoogleUserInfoResponseDTO googleUserInfoResponseDto, String role) {

--- a/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
+++ b/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
@@ -1,12 +1,15 @@
 package com.example.demo.oauth2.controller;
 
 import com.example.demo.member.service.MemberRegistryService;
+import com.example.demo.oauth2.dto.ReissueDTO;
 import com.example.demo.oauth2.google.dto.GoogleLoginDTO;
 import com.example.demo.oauth2.google.dto.GoogleUserInfoResponseDTO;
 import com.example.demo.oauth2.google.service.GoogleService;
 import com.example.demo.oauth2.kakao.dto.KakaoLoginDTO;
 import com.example.demo.oauth2.kakao.dto.KakaoUserInfoResponseDTO;
 import com.example.demo.oauth2.kakao.service.KakaoService;
+import com.example.demo.oauth2.service.Oauth2Service;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.security.auth.RefreshFailedException;
+
 @RequiredArgsConstructor
 @Slf4j
 @RestController
@@ -26,6 +31,7 @@ public class Oauth2Controller {
 
     private final KakaoService kakaoService;
     private final GoogleService googleService;
+    private final Oauth2Service oauth2Service;
 
     private final MemberRegistryService memberRegistryService;
 
@@ -39,17 +45,31 @@ public class Oauth2Controller {
         return ResponseEntity.status(200).body(loginResponse);
     }
 
+    @PostMapping("/shared/login-test")
+    @Operation(summary = "[공통] 로그인 테스트")
+    public ResponseEntity<KakaoLoginDTO.Response> loginTest(@RequestBody KakaoLoginDTO.Request loginRequest) {
+        KakaoUserInfoResponseDTO userInfo = null;
+        String role = loginRequest.getRole();
+
+        KakaoLoginDTO.Response loginResponse = memberRegistryService.createTestMember(userInfo, role);
+        return ResponseEntity.status(200).body(loginResponse);
+    }
+
     @PostMapping("/shared/google")
     @Operation(summary = "[공통] 구글 로그인")
     public ResponseEntity<GoogleLoginDTO.Response> googleLogin(@RequestBody GoogleLoginDTO.Request loginRequest) {
         GoogleUserInfoResponseDTO userInfo = googleService.getGoogleMemberInfo(loginRequest.getGoogleAccessToken());
         String role = loginRequest.getRole();
 
-        log.info("userInfo : {}", userInfo);
-
         GoogleLoginDTO.Response loginResponse = memberRegistryService.createGoogleMember(userInfo, role);
         return ResponseEntity.status(200).body(loginResponse);
     }
 
+    @PostMapping("/shared/reissue")
+    @Operation(summary = "[공통] 리프레시 토큰(RT)을 통한 AT,RT 재발급")
+    public ResponseEntity<ReissueDTO.Response> reissueJwtToken(@RequestBody ReissueDTO.Request request) throws RefreshFailedException, JsonProcessingException {
+        ReissueDTO.Response reissueResponse = oauth2Service.reissueJwtToken(request);
 
+        return ResponseEntity.status(200).body(reissueResponse);
+    }
 }

--- a/demo/src/main/java/com/example/demo/oauth2/dto/ReissueDTO.java
+++ b/demo/src/main/java/com/example/demo/oauth2/dto/ReissueDTO.java
@@ -1,0 +1,33 @@
+package com.example.demo.oauth2.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class ReissueDTO {
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String refreshToken;
+    }
+
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String accessToken;
+
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String refreshToken;
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
+++ b/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
@@ -1,0 +1,68 @@
+package com.example.demo.oauth2.service;
+
+import com.example.demo.enums.member.MemberRole;
+import com.example.demo.jwt.TokenProvider;
+import com.example.demo.member.domain.Customer;
+import com.example.demo.member.domain.WeddingPlanner;
+import com.example.demo.member.service.CustomUserDetailsService;
+import com.example.demo.oauth2.dto.ReissueDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.security.auth.RefreshFailedException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class Oauth2Service {
+
+    private final TokenProvider tokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Transactional
+    public ReissueDTO.Response reissueJwtToken(ReissueDTO.Request request) throws JsonProcessingException, RefreshFailedException {
+        String refreshToken = request.getRefreshToken();
+
+        if (refreshToken == null) {
+            throw new NullPointerException("No refresh token found in request");
+        }
+
+        long refreshTokenExpiration = tokenProvider.getRefreshTokenExpirationByManual(refreshToken);
+
+        if (refreshTokenExpiration <= 0) {
+            throw new RefreshFailedException("Refresh token is expired");
+        }
+
+        String UUID = tokenProvider.getUniqueId(refreshToken);
+
+        MemberRole memberRole = customUserDetailsService.getCurrentAuthenticatedMemberRole();
+
+        String accessToken = null;
+        String newRefreshToken = null;
+
+        if (memberRole == MemberRole.CUSTOMER) {
+            Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
+            accessToken = tokenProvider.createAccessToken(customer.getName(), UUID);
+            newRefreshToken = tokenProvider.createRefreshToken(customer.getName(), UUID);
+            customer.updateRefreshToken(newRefreshToken);
+        } else if (memberRole == MemberRole.WEDDING_PLANNER) {
+            WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
+            accessToken = tokenProvider.createAccessToken(weddingPlanner.getName(), UUID);
+            newRefreshToken = tokenProvider.createRefreshToken(weddingPlanner.getName(), UUID);
+            weddingPlanner.updateRefreshToken(newRefreshToken);
+        }
+        Authentication authentication = customUserDetailsService.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return ReissueDTO.Response.builder()
+                .accessToken(accessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
+
+}

--- a/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
+++ b/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
@@ -32,6 +32,8 @@ public class Oauth2Service {
             throw new NullPointerException("No refresh token found in request");
         }
 
+        tokenProvider.validateRefreshToken(refreshToken);
+
         long refreshTokenExpiration = tokenProvider.getRefreshTokenExpirationByManual(refreshToken);
 
         if (refreshTokenExpiration <= 0) {


### PR DESCRIPTION
### PR 요약
리프레시 토큰 이용하여 AT, RT 재발급

### 변경 사항
- 리프레시 토큰 넣어 AT, RT 재발급 하는 API 개발
  - context에서 현재 유저의 정보, Role을 파악하기 때문에 이슈 발생 가능성 존재함. 프론트 연결하며 확인 필요.
- 유효하지 않은 토큰일 때의 `REFRESH_TOKEN_EXPIRED_ERROR` Global Exception에 추가

### 참고 사항
- 테스트용 더미 로그인(엑세스토큰 잘 받았다고 가정하고, Clara에 대한 JWT 발급) 구현
