### PR TITLE
Feat/Logout with saving refresh token at Redis

### DIFF
--- a/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
+++ b/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
@@ -32,7 +32,8 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
     private final CustomUserDetailsService customUserDetailsService;
 
     private static final List<String> WHITELIST = Arrays.asList(
-            "/api/v1/oauth2/shared/reissue"
+            "/api/v1/oauth2/shared/reissue",
+            "/redis/set/get/all"
     );
 
     @Override

--- a/demo/src/main/java/com/example/demo/member/domain/Customer.java
+++ b/demo/src/main/java/com/example/demo/member/domain/Customer.java
@@ -50,12 +50,5 @@ public class Customer {
     @OneToMany
     @JoinColumn(name = "customer_id")
     private List<ChatRoom> chatRooms;
-
-    @Column
-    private String refreshToken;
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
+    
 }

--- a/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
+++ b/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
@@ -53,11 +53,4 @@ public class WeddingPlanner {
     @JoinColumn(name = "weddingplanner_id")
     private List<ChatRoom> chatRooms;
 
-    @Column
-    private String refreshToken;
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
 }

--- a/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
+++ b/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
@@ -67,12 +67,6 @@ public class Oauth2Controller {
     public ResponseEntity<ReissueDTO.Response> reissueJwtToken(@RequestBody ReissueDTO.Request request) throws RefreshFailedException, JsonProcessingException {
         ReissueDTO.Response reissueResponse = oauth2Service.reissueJwtToken(request);
 
-<<<<<<< Updated upstream
-        return ResponseEntity.status(200).body(reissueResponse);
-    }
-=======
-<<<<<<< Updated upstream
-=======
         return ResponseEntity.status(200).body(reissueResponse);
     }
 
@@ -82,8 +76,6 @@ public class Oauth2Controller {
         oauth2Service.logout();
         return ResponseEntity.status(200).build();
     }
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 }
 
 

--- a/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
+++ b/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
@@ -15,10 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.security.auth.RefreshFailedException;
 
@@ -70,6 +67,23 @@ public class Oauth2Controller {
     public ResponseEntity<ReissueDTO.Response> reissueJwtToken(@RequestBody ReissueDTO.Request request) throws RefreshFailedException, JsonProcessingException {
         ReissueDTO.Response reissueResponse = oauth2Service.reissueJwtToken(request);
 
+<<<<<<< Updated upstream
         return ResponseEntity.status(200).body(reissueResponse);
     }
+=======
+<<<<<<< Updated upstream
+=======
+        return ResponseEntity.status(200).body(reissueResponse);
+    }
+
+    @GetMapping("/shared/logout")
+    @Operation(summary = "[공통] 로그아웃")
+    public ResponseEntity<Void> logout() {
+        oauth2Service.logout();
+        return ResponseEntity.status(200).build();
+    }
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 }
+
+

--- a/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
+++ b/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
@@ -9,20 +9,15 @@ import com.example.demo.oauth2.dto.ReissueDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-<<<<<<< Updated upstream
-=======
 import org.springframework.data.redis.core.RedisTemplate;
->>>>>>> Stashed changes
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.security.auth.RefreshFailedException;
-<<<<<<< Updated upstream
-=======
 import java.util.concurrent.TimeUnit;
->>>>>>> Stashed changes
+
 
 @Slf4j
 @Service
@@ -32,11 +27,8 @@ public class Oauth2Service {
     private final TokenProvider tokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
 
-<<<<<<< Updated upstream
-=======
     private final RedisTemplate<String, Object> redisTemplateRT;
 
->>>>>>> Stashed changes
     @Transactional
     public ReissueDTO.Response reissueJwtToken(ReissueDTO.Request request) throws JsonProcessingException, RefreshFailedException {
         String refreshToken = request.getRefreshToken();
@@ -49,13 +41,10 @@ public class Oauth2Service {
 
         long refreshTokenExpiration = tokenProvider.getRefreshTokenExpirationByManual(refreshToken);
 
-<<<<<<< Updated upstream
-        if (refreshTokenExpiration <= 0) {
-=======
 
         String expiredKey = "expired:" + refreshToken;
         if (refreshTokenExpiration <= 0 || Boolean.TRUE.equals(redisTemplateRT.hasKey(expiredKey))) {
->>>>>>> Stashed changes
+
             throw new RefreshFailedException("Refresh token is expired");
         }
 
@@ -86,8 +75,6 @@ public class Oauth2Service {
                 .build();
     }
 
-<<<<<<< Updated upstream
-=======
     @Transactional
     public void logout() {
         MemberRole memberRole = customUserDetailsService.getCurrentAuthenticatedMemberRole();
@@ -106,8 +93,8 @@ public class Oauth2Service {
             expiredKey = "expired:" + refreshToken;
             weddingPlanner.updateRefreshToken(null);
         }
-        
+
         redisTemplateRT.opsForValue().set(expiredKey, "blacklisted", tokenProvider.getRefreshTokenExpiration(refreshToken), TimeUnit.MILLISECONDS);
     }
->>>>>>> Stashed changes
+
 }

--- a/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
+++ b/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
@@ -9,12 +9,20 @@ import com.example.demo.oauth2.dto.ReissueDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+<<<<<<< Updated upstream
+=======
+import org.springframework.data.redis.core.RedisTemplate;
+>>>>>>> Stashed changes
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.security.auth.RefreshFailedException;
+<<<<<<< Updated upstream
+=======
+import java.util.concurrent.TimeUnit;
+>>>>>>> Stashed changes
 
 @Slf4j
 @Service
@@ -24,6 +32,11 @@ public class Oauth2Service {
     private final TokenProvider tokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
 
+<<<<<<< Updated upstream
+=======
+    private final RedisTemplate<String, Object> redisTemplateRT;
+
+>>>>>>> Stashed changes
     @Transactional
     public ReissueDTO.Response reissueJwtToken(ReissueDTO.Request request) throws JsonProcessingException, RefreshFailedException {
         String refreshToken = request.getRefreshToken();
@@ -36,7 +49,13 @@ public class Oauth2Service {
 
         long refreshTokenExpiration = tokenProvider.getRefreshTokenExpirationByManual(refreshToken);
 
+<<<<<<< Updated upstream
         if (refreshTokenExpiration <= 0) {
+=======
+
+        String expiredKey = "expired:" + refreshToken;
+        if (refreshTokenExpiration <= 0 || Boolean.TRUE.equals(redisTemplateRT.hasKey(expiredKey))) {
+>>>>>>> Stashed changes
             throw new RefreshFailedException("Refresh token is expired");
         }
 
@@ -67,4 +86,28 @@ public class Oauth2Service {
                 .build();
     }
 
+<<<<<<< Updated upstream
+=======
+    @Transactional
+    public void logout() {
+        MemberRole memberRole = customUserDetailsService.getCurrentAuthenticatedMemberRole();
+
+        String expiredKey = null;
+        String refreshToken = null;
+
+        if (memberRole == MemberRole.CUSTOMER) {
+            Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
+            refreshToken = customer.getRefreshToken();
+            expiredKey = "expired:" + refreshToken;
+            customer.updateRefreshToken(null);
+        } else if (memberRole == MemberRole.WEDDING_PLANNER) {
+            WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
+            refreshToken = weddingPlanner.getRefreshToken();
+            expiredKey = "expired:" + refreshToken;
+            weddingPlanner.updateRefreshToken(null);
+        }
+        
+        redisTemplateRT.opsForValue().set(expiredKey, "blacklisted", tokenProvider.getRefreshTokenExpiration(refreshToken), TimeUnit.MILLISECONDS);
+    }
+>>>>>>> Stashed changes
 }

--- a/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
+++ b/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
@@ -23,14 +23,14 @@ public class RedisController {
     @GetMapping("/set/all")
     @Operation(summary = "Value가 Set인 모든 데이터 조회")
     public Map<String, Set<Object>> getAllSetValue() {
-        log.info("Getting all set values");
+        log.info("[Redis] Getting all set values");
         return redisService.getAllSetPairs();
     }
 
     @GetMapping("/set/get")
     @Operation(summary = "Value가 Set인 특정 데이터 조회")
     public String getSetValue(@RequestParam String key) {
-        log.info("Getting set value for key: {}", key);
+        log.info("[Redis] Getting set value for key: {}", key);
         String value = redisService.getSetValue(key);
         return value;
     }
@@ -38,21 +38,21 @@ public class RedisController {
     @GetMapping("/set/delete/all")
     @Operation(summary = "Value가 Set인 모든 데이터 삭제")
     public void deleteAllSetValues() {
-        log.info("Deleting all set values for key");
+        log.info("[Redis] Deleting all set values for key");
         redisService.deleteAllSet();
     }
 
     @GetMapping("/every/all")
     @Operation(summary = "모든 데이터 조회")
     public Map<String, Object> getAllData() {
-        log.info("Getting all values");
+        log.info("[Redis] Getting all values");
         return redisService.getAllData();
     }
 
     @GetMapping("/every/delete/all")
     @Operation(summary = "모든 데이터 삭제")
     public void deleteAllData() {
-        log.info("Deleting all values");
+        log.info("[Redis] Deleting all values");
         redisService.deleteAllData();
     }
 

--- a/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
+++ b/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
@@ -1,6 +1,7 @@
 package com.example.demo.redis.controller;
 
 import com.example.demo.redis.service.RedisService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,33 +20,50 @@ public class RedisController {
 
     private final RedisService redisService;
 
-    @GetMapping("/set/get/all")
+    @GetMapping("/set/all")
+    @Operation(summary = "Value가 Set인 모든 데이터 조회")
     public Map<String, Set<Object>> getAllSetValue() {
         log.info("Getting all set values");
         return redisService.getAllSetPairs();
     }
 
-    @GetMapping("/all/exists")
-    public boolean checkExistsValue(@RequestParam String key) {
-        log.info("Checking existence for key: {}", key);
-        boolean exists = redisService.checkExistsValue(redisService.getValue(key));
-        log.info("Existence check for key: {} is: {}", key, exists);
-        return exists;
-    }
-
     @GetMapping("/set/get")
+    @Operation(summary = "Value가 Set인 특정 데이터 조회")
     public String getSetValue(@RequestParam String key) {
         log.info("Getting set value for key: {}", key);
         String value = redisService.getSetValue(key);
         return value;
     }
 
-    @GetMapping("set/delete/all")
+    @GetMapping("/set/delete/all")
+    @Operation(summary = "Value가 Set인 모든 데이터 삭제")
     public void deleteAllSetValues() {
         log.info("Deleting all set values for key");
         redisService.deleteAllSet();
     }
 
+    @GetMapping("/every/all")
+    @Operation(summary = "모든 데이터 조회")
+    public Map<String, Object> getAllData() {
+        log.info("Getting all values");
+        return redisService.getAllData();
+    }
+
+    @GetMapping("/every/delete/all")
+    @Operation(summary = "모든 데이터 삭제")
+    public void deleteAllData() {
+        log.info("Deleting all values");
+        redisService.deleteAllData();
+    }
+
+//     @GetMapping("/all/exists")
+//    public boolean checkExistsValue(@RequestParam String key) {
+//        log.info("Checking existence for key: {}", key);
+//        boolean exists = redisService.checkExistsValue(redisService.getValue(key));
+//        log.info("Existence check for key: {} is: {}", key, exists);
+//        return exists;
+//    }
+//
 //    @PostMapping("/set")
 //    public void setValue(@RequestParam String key, @RequestParam String value) {
 //        log.info("Setting value for key: {}", key);

--- a/demo/src/main/java/com/example/demo/redis/service/RedisService.java
+++ b/demo/src/main/java/com/example/demo/redis/service/RedisService.java
@@ -149,4 +149,29 @@ public class RedisService {
         return allSetPairs;
     }
 
+    // retrieve every data in redis
+    public Map<String, Object> getAllData() {
+        Set<String> allKeys = redisTemplate.keys("*");  // get all keys
+        Map<String, Object> allData = new HashMap<>();  // create a map to store key-value pairs
+
+        if (allKeys != null) {
+            for (String key : allKeys) {
+                Object value = redisTemplate.opsForValue().get(key);  // retrieve value
+                if (value != null) {
+                    allData.put(key, value);  // store the key and its value in the map
+                }
+            }
+        }
+        return allData;
+    }
+
+    // delete every data in redis
+    public void deleteAllData() {
+        Set<String> allKeys = redisTemplate.keys("*");  // get all keys
+        if (allKeys != null) {
+            for (String key : allKeys) {
+                redisTemplate.delete(key);  // delete the key
+            }
+        }
+    }
 }


### PR DESCRIPTION
 ### PR 요약
OAuth2 로그아웃 구현

### 변경 사항
- 로그인 시 `UUID : Refresh Token` 키페어를 Redis에서 관리
- 추후 AT/RT 재발급 시, Redis에서 비교
- `RTR(Refresh Token Rotation)`시, Redis에 있는 RT replace

### 참고 사항
