### PR TITLE
Feat/OAuth2 Social Login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       KAKAO_CLIENT_ID_NATIVE: ${{ secrets.KAKAO_CLIENT_ID_NATIVE }}
       KAKAO_CLIENT_ID_WEB: ${{ secrets.KAKAO_CLIENT_ID_WEB }}
       KAKAO_SECRET_ID_WEB: ${{ secrets.KAKAO_SECRET_ID_WEB }}
-      GOOGLE_CLIENT_ID_WEB: ${{ secrets.GOOGLE_CLIENT_ID_WEB }}
-      GOOGLE_CLIENT_SECRET_WEB: ${{ secrets.GOOGLE_CLIENT_SECRET_WEB }}
+      GOOGLE_CLIENT_ID_ANDROID: ${{ secrets.GOOGLE_CLIENT_ID_ANDROID }}
+      GOOGLE_CLIENT_ID_IOS: ${{ secrets.GOOGLE_CLIENT_ID_IOS }}
 
     permissions:
       checks: write

--- a/demo/src/main/java/com/example/demo/config/JwtAuthenticationFilter.java
+++ b/demo/src/main/java/com/example/demo/config/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -30,6 +31,7 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String accessToken = resolveToken(request);
+
         if (StringUtils.hasText(accessToken)) {
             try {
                 // load user by JWT access token
@@ -52,6 +54,8 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(7);
         }
-        return null;
+        // throw 401 unauthorized error
+        throw new AuthenticationException("JWT Token is not valid") {
+        };
     }
 }

--- a/demo/src/main/java/com/example/demo/config/JwtAuthenticationFilter.java
+++ b/demo/src/main/java/com/example/demo/config/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -54,8 +53,6 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(7);
         }
-        // throw 401 unauthorized error
-        throw new AuthenticationException("JWT Token is not valid") {
-        };
+        return null;
     }
 }

--- a/demo/src/main/java/com/example/demo/config/JwtAuthenticationFilter.java
+++ b/demo/src/main/java/com/example/demo/config/JwtAuthenticationFilter.java
@@ -29,10 +29,11 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String UUID = resolveToken(request);
-        if (StringUtils.hasText(UUID)) {
+        String accessToken = resolveToken(request);
+        if (StringUtils.hasText(accessToken)) {
             try {
-                UserDetails userDetails = customUserDetailsService.loadUserByUsername(UUID);
+                // load user by JWT access token
+                UserDetails userDetails = customUserDetailsService.loadUserByAccessToken(accessToken);
 
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/demo/src/main/java/com/example/demo/discord/DiscordMessageProvider.java
+++ b/demo/src/main/java/com/example/demo/discord/DiscordMessageProvider.java
@@ -46,8 +46,6 @@ public class DiscordMessageProvider {
                 request.getTitle(),          // title
                 request.getContent(),        // description
                 4886754,                     // color (Cyan)
-//                new DiscordMessage.Image("https://example.com/image.png"),
-//                new DiscordMessage.Thumbnail("https://example.com/thumbnail.png"),
                 new CustomerServiceMessage.Author(username),
                 List.of(
                         new CustomerServiceMessage.Field("Role", role.getRoleName(), true),
@@ -75,7 +73,7 @@ public class DiscordMessageProvider {
                         new ExceptionMessage.Field("Division Code", response.getDivisionCode(), true),
                         new ExceptionMessage.Field("Request URL", getRequestPath(), true),
                         new ExceptionMessage.Field("Username", userInfo.username(), true),
-//                        new ExceptionMessage.Field("Role", userInfo.role().getRoleName(), true),
+                        new ExceptionMessage.Field("Role", userInfo.role().getRoleName(), true),
                         new ExceptionMessage.Field("UUID", userInfo.UUID(), true)
                 ),
                 new ExceptionMessage.Footer(formattedTimestamp)

--- a/demo/src/main/java/com/example/demo/error/ErrorCode.java
+++ b/demo/src/main/java/com/example/demo/error/ErrorCode.java
@@ -82,7 +82,10 @@ public enum ErrorCode {
     USERNAME_NOT_FOUND_ERROR(404, "G014", "Username Not Found Exception"),
 
     // token expired
-    REFRESH_TOKEN_EXPIRED_ERROR(401, "G015", "Refresh Token Expired Exception");
+    REFRESH_TOKEN_EXPIRED_ERROR(401, "G015", "Refresh Token Expired Exception"),
+
+    // unauthorized
+    UNAUTHORIZED_ERROR(401, "G016", "Unauthorized Exception");
 
     /**
      * ******************************* Error Code Constructor ***************************************

--- a/demo/src/main/java/com/example/demo/error/ErrorCode.java
+++ b/demo/src/main/java/com/example/demo/error/ErrorCode.java
@@ -79,7 +79,10 @@ public enum ErrorCode {
     FEIGN_CLIENT_ERROR(400, "G013", "Feign Client Error Exception"),
 
     // UsernameNotFoundException
-    USERNAME_NOT_FOUND_ERROR(404, "G014", "Username Not Found Exception");
+    USERNAME_NOT_FOUND_ERROR(404, "G014", "Username Not Found Exception"),
+
+    // token expired
+    REFRESH_TOKEN_EXPIRED_ERROR(401, "G015", "Refresh Token Expired Exception");
 
     /**
      * ******************************* Error Code Constructor ***************************************

--- a/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
+++ b/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import javax.security.auth.RefreshFailedException;
 import java.io.IOException;
 
 @Slf4j
@@ -165,6 +166,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(JsonParseException.class)
     protected ResponseEntity<ErrorResponse> handleJsonParseExceptionException(JsonParseException ex) {
         return buildErrorResponseAndSendAlert(ex, ErrorCode.JSON_PARSE_ERROR, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * @param ex RefreshFailedException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(RefreshFailedException.class)
+    protected ResponseEntity<ErrorResponse> handleRefreshFailedException(RefreshFailedException ex) {
+        return buildErrorResponseAndSendAlert(ex, ErrorCode.REFRESH_TOKEN_EXPIRED_ERROR, HttpStatus.BAD_REQUEST);
     }
 
     /**

--- a/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
+++ b/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
@@ -117,9 +117,25 @@ public class TokenProvider implements InitializingBean {
         return claims.getSubject();
     }
 
-    public boolean validateAccessToken(String token) {
+    public boolean validateAccessToken(String accessToken) {
         try {
-            Jwts.parser().setSigningKey(key).parseClaimsJws(token);
+            Jwts.parser().setSigningKey(key).parseClaimsJws(accessToken);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            logger.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            logger.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            logger.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            logger.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            Jwts.parser().setSigningKey(key).parseClaimsJws(refreshToken);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             logger.info("잘못된 JWT 서명입니다.");

--- a/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
+++ b/demo/src/main/java/com/example/demo/jwt/TokenProvider.java
@@ -117,11 +117,6 @@ public class TokenProvider implements InitializingBean {
         return claims.getSubject();
     }
 
-//    public Authentication getAuthentication(String token) {
-//        UserDetails userDetails = userDetailsService.loadUserByUsername(getUniqueId(token));
-//        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-//    }
-
     public boolean validateAccessToken(String token) {
         try {
             Jwts.parser().setSigningKey(key).parseClaimsJws(token);

--- a/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
+++ b/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
@@ -32,7 +32,8 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
     private final CustomUserDetailsService customUserDetailsService;
 
     private static final List<String> WHITELIST = Arrays.asList(
-            "/api/v1/oauth2/shared/reissue"
+            "/api/v1/oauth2/shared/reissue",
+            "/redis/set/get/all"
     );
 
     @Override

--- a/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
+++ b/demo/src/main/java/com/example/demo/jwt/handler/JwtExceptionHandlerFilter.java
@@ -32,7 +32,7 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
     private final CustomUserDetailsService customUserDetailsService;
 
     private static final List<String> WHITELIST = Arrays.asList(
-            "/api/v1/member/reissue"
+            "/api/v1/oauth2/shared/reissue"
     );
 
     @Override

--- a/demo/src/main/java/com/example/demo/member/domain/Customer.java
+++ b/demo/src/main/java/com/example/demo/member/domain/Customer.java
@@ -50,12 +50,5 @@ public class Customer {
     @OneToMany
     @JoinColumn(name = "customer_id")
     private List<ChatRoom> chatRooms;
-
-    @Column
-    private String refreshToken;
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
+    
 }

--- a/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
+++ b/demo/src/main/java/com/example/demo/member/domain/WeddingPlanner.java
@@ -53,11 +53,4 @@ public class WeddingPlanner {
     @JoinColumn(name = "weddingplanner_id")
     private List<ChatRoom> chatRooms;
 
-    @Column
-    private String refreshToken;
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
 }

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -240,18 +240,14 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     public Customer getCustomerByUuid(String uuid) {
         log.info("Getting customer by UUID: {}", uuid);
-        Customer customer = customerRepository.findByUUID(uuid)
+        return customerRepository.findByUUID(uuid)
                 .orElseThrow(() -> new RuntimeException("Customer not found"));
-        log.info("Found customer with UUID: {}", uuid);
-        return customer;
     }
 
     public WeddingPlanner getWeddingPlannerByUuid(String uuid) {
         log.info("Getting wedding planner by UUID: {}", uuid);
-        WeddingPlanner weddingPlanner = weddingPlannerRepository.findByUUID(uuid)
+        return weddingPlannerRepository.findByUUID(uuid)
                 .orElseThrow(() -> new RuntimeException("WeddingPlanner not found"));
-        log.info("Found wedding planner with UUID: {}", uuid);
-        return weddingPlanner;
     }
 
     public MypageDTO.CustomerServiceResponse createCustomerService(MypageDTO.CustomerServiceRequest customerServiceRequest) {

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -75,6 +75,12 @@ public class CustomUserDetailsService implements UserDetailsService {
         throw new UsernameNotFoundException("User with the given UUID could not be found");
     }
 
+    public UserDetails loadUserByAccessToken(String accessToken) throws UsernameNotFoundException {
+        log.info("Loading user by Access Token: {}", accessToken);
+        String UUID = tokenProvider.getUniqueId(accessToken);
+        return loadUserByUsername(UUID);
+    }
+
     @Transactional
     public AuthDTO.Response join(String role) {
         log.info("Joining new member with role: {}", role);

--- a/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
+++ b/demo/src/main/java/com/example/demo/member/service/CustomUserDetailsService.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -125,7 +126,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         throw new UsernameNotFoundException("Authenticated customer not found");
     }
 
-    public WeddingPlanner getCurrentAuthenticatedWeddingPlanner() throws UsernameNotFoundException {
+    public WeddingPlanner getCurrentAuthenticatedWeddingPlanner() throws AuthenticationException {
         log.info("Getting current authenticated wedding planner");
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated() && !(authentication instanceof AnonymousAuthenticationToken)) {
@@ -136,7 +137,8 @@ public class CustomUserDetailsService implements UserDetailsService {
             return weddingPlanner;
         }
         log.error("Authenticated wedding planner not found");
-        throw new UsernameNotFoundException("Authenticated wedding planner not found");
+        throw new AuthenticationException("JWT Token is not valid") {
+        };
     }
 
     public MemberRole getCurrentAuthenticatedMemberRole() {

--- a/demo/src/main/java/com/example/demo/member/service/MemberRegistryService.java
+++ b/demo/src/main/java/com/example/demo/member/service/MemberRegistryService.java
@@ -30,6 +30,7 @@ public class MemberRegistryService {
     @Transactional
     public KakaoLoginDTO.Response createKakaoMember(KakaoUserInfoResponseDTO userInfoResponseDto, String role) {
         String username = userInfoResponseDto.kakaoAccount.profile.nickName;
+
         String UUID = generateUUID("kakao", userInfoResponseDto.id.toString());
 
         // Generate access and refresh tokens
@@ -45,6 +46,35 @@ public class MemberRegistryService {
 
         return buildKakaoLoginResponse(UUID, accessToken, refreshToken);
     }
+
+    @Transactional
+    public KakaoLoginDTO.Response createTestMember(KakaoUserInfoResponseDTO userInfoResponseDto, String role) {
+        String username;
+        Long id;
+        if (userInfoResponseDto == null) {
+            username = "test";
+            id = 1L;
+        } else {
+            username = userInfoResponseDto.kakaoAccount.profile.nickName;
+            id = userInfoResponseDto.id;
+        }
+
+        String UUID = "51fc7d6b-7f86-43cf-b5c7-de4c46046d71";
+
+        // Generate access and refresh tokens
+        String accessToken = tokenProvider.createAccessToken(username, UUID);
+        String refreshToken = tokenProvider.createRefreshToken(username, UUID);
+
+        // Delegate customer or wedding planner handling based on role
+        if (role.equals(MemberRole.CUSTOMER.getRoleName())) {
+            processCustomer(UUID, username, refreshToken);
+        } else if (role.equals(MemberRole.WEDDING_PLANNER.getRoleName())) {
+            processWeddingPlanner(UUID, username, refreshToken);
+        }
+
+        return buildKakaoLoginResponse(UUID, accessToken, refreshToken);
+    }
+
 
     @Transactional
     public GoogleLoginDTO.Response createGoogleMember(GoogleUserInfoResponseDTO googleUserInfoResponseDto, String role) {

--- a/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
+++ b/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
@@ -67,12 +67,6 @@ public class Oauth2Controller {
     public ResponseEntity<ReissueDTO.Response> reissueJwtToken(@RequestBody ReissueDTO.Request request) throws RefreshFailedException, JsonProcessingException {
         ReissueDTO.Response reissueResponse = oauth2Service.reissueJwtToken(request);
 
-<<<<<<< Updated upstream
-        return ResponseEntity.status(200).body(reissueResponse);
-    }
-=======
-<<<<<<< Updated upstream
-=======
         return ResponseEntity.status(200).body(reissueResponse);
     }
 
@@ -82,8 +76,6 @@ public class Oauth2Controller {
         oauth2Service.logout();
         return ResponseEntity.status(200).build();
     }
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 }
 
 

--- a/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
+++ b/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
@@ -1,12 +1,15 @@
 package com.example.demo.oauth2.controller;
 
 import com.example.demo.member.service.MemberRegistryService;
+import com.example.demo.oauth2.dto.ReissueDTO;
 import com.example.demo.oauth2.google.dto.GoogleLoginDTO;
 import com.example.demo.oauth2.google.dto.GoogleUserInfoResponseDTO;
 import com.example.demo.oauth2.google.service.GoogleService;
 import com.example.demo.oauth2.kakao.dto.KakaoLoginDTO;
 import com.example.demo.oauth2.kakao.dto.KakaoUserInfoResponseDTO;
 import com.example.demo.oauth2.kakao.service.KakaoService;
+import com.example.demo.oauth2.service.Oauth2Service;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.security.auth.RefreshFailedException;
+
 @RequiredArgsConstructor
 @Slf4j
 @RestController
@@ -26,6 +31,7 @@ public class Oauth2Controller {
 
     private final KakaoService kakaoService;
     private final GoogleService googleService;
+    private final Oauth2Service oauth2Service;
 
     private final MemberRegistryService memberRegistryService;
 
@@ -39,17 +45,31 @@ public class Oauth2Controller {
         return ResponseEntity.status(200).body(loginResponse);
     }
 
+    @PostMapping("/shared/login-test")
+    @Operation(summary = "[공통] 로그인 테스트")
+    public ResponseEntity<KakaoLoginDTO.Response> loginTest(@RequestBody KakaoLoginDTO.Request loginRequest) {
+        KakaoUserInfoResponseDTO userInfo = null;
+        String role = loginRequest.getRole();
+
+        KakaoLoginDTO.Response loginResponse = memberRegistryService.createTestMember(userInfo, role);
+        return ResponseEntity.status(200).body(loginResponse);
+    }
+
     @PostMapping("/shared/google")
     @Operation(summary = "[공통] 구글 로그인")
     public ResponseEntity<GoogleLoginDTO.Response> googleLogin(@RequestBody GoogleLoginDTO.Request loginRequest) {
         GoogleUserInfoResponseDTO userInfo = googleService.getGoogleMemberInfo(loginRequest.getGoogleAccessToken());
         String role = loginRequest.getRole();
 
-        log.info("userInfo : {}", userInfo);
-
         GoogleLoginDTO.Response loginResponse = memberRegistryService.createGoogleMember(userInfo, role);
         return ResponseEntity.status(200).body(loginResponse);
     }
 
+    @PostMapping("/shared/reissue")
+    @Operation(summary = "[공통] 리프레시 토큰(RT)을 통한 AT,RT 재발급")
+    public ResponseEntity<ReissueDTO.Response> reissueJwtToken(@RequestBody ReissueDTO.Request request) throws RefreshFailedException, JsonProcessingException {
+        ReissueDTO.Response reissueResponse = oauth2Service.reissueJwtToken(request);
 
+        return ResponseEntity.status(200).body(reissueResponse);
+    }
 }

--- a/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
+++ b/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
@@ -15,10 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.security.auth.RefreshFailedException;
 
@@ -70,6 +67,23 @@ public class Oauth2Controller {
     public ResponseEntity<ReissueDTO.Response> reissueJwtToken(@RequestBody ReissueDTO.Request request) throws RefreshFailedException, JsonProcessingException {
         ReissueDTO.Response reissueResponse = oauth2Service.reissueJwtToken(request);
 
+<<<<<<< Updated upstream
         return ResponseEntity.status(200).body(reissueResponse);
     }
+=======
+<<<<<<< Updated upstream
+=======
+        return ResponseEntity.status(200).body(reissueResponse);
+    }
+
+    @GetMapping("/shared/logout")
+    @Operation(summary = "[공통] 로그아웃")
+    public ResponseEntity<Void> logout() {
+        oauth2Service.logout();
+        return ResponseEntity.status(200).build();
+    }
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 }
+
+

--- a/demo/src/main/java/com/example/demo/oauth2/dto/ReissueDTO.java
+++ b/demo/src/main/java/com/example/demo/oauth2/dto/ReissueDTO.java
@@ -1,0 +1,33 @@
+package com.example.demo.oauth2.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class ReissueDTO {
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String refreshToken;
+    }
+
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String accessToken;
+
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String refreshToken;
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
+++ b/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
@@ -9,20 +9,15 @@ import com.example.demo.oauth2.dto.ReissueDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-<<<<<<< Updated upstream
-=======
 import org.springframework.data.redis.core.RedisTemplate;
->>>>>>> Stashed changes
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.security.auth.RefreshFailedException;
-<<<<<<< Updated upstream
-=======
 import java.util.concurrent.TimeUnit;
->>>>>>> Stashed changes
+
 
 @Slf4j
 @Service
@@ -32,11 +27,8 @@ public class Oauth2Service {
     private final TokenProvider tokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
 
-<<<<<<< Updated upstream
-=======
     private final RedisTemplate<String, Object> redisTemplateRT;
 
->>>>>>> Stashed changes
     @Transactional
     public ReissueDTO.Response reissueJwtToken(ReissueDTO.Request request) throws JsonProcessingException, RefreshFailedException {
         String refreshToken = request.getRefreshToken();
@@ -49,13 +41,10 @@ public class Oauth2Service {
 
         long refreshTokenExpiration = tokenProvider.getRefreshTokenExpirationByManual(refreshToken);
 
-<<<<<<< Updated upstream
-        if (refreshTokenExpiration <= 0) {
-=======
 
         String expiredKey = "expired:" + refreshToken;
         if (refreshTokenExpiration <= 0 || Boolean.TRUE.equals(redisTemplateRT.hasKey(expiredKey))) {
->>>>>>> Stashed changes
+
             throw new RefreshFailedException("Refresh token is expired");
         }
 
@@ -86,8 +75,6 @@ public class Oauth2Service {
                 .build();
     }
 
-<<<<<<< Updated upstream
-=======
     @Transactional
     public void logout() {
         MemberRole memberRole = customUserDetailsService.getCurrentAuthenticatedMemberRole();
@@ -106,8 +93,8 @@ public class Oauth2Service {
             expiredKey = "expired:" + refreshToken;
             weddingPlanner.updateRefreshToken(null);
         }
-        
+
         redisTemplateRT.opsForValue().set(expiredKey, "blacklisted", tokenProvider.getRefreshTokenExpiration(refreshToken), TimeUnit.MILLISECONDS);
     }
->>>>>>> Stashed changes
+
 }

--- a/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
+++ b/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
@@ -9,12 +9,20 @@ import com.example.demo.oauth2.dto.ReissueDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+<<<<<<< Updated upstream
+=======
+import org.springframework.data.redis.core.RedisTemplate;
+>>>>>>> Stashed changes
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.security.auth.RefreshFailedException;
+<<<<<<< Updated upstream
+=======
+import java.util.concurrent.TimeUnit;
+>>>>>>> Stashed changes
 
 @Slf4j
 @Service
@@ -24,6 +32,11 @@ public class Oauth2Service {
     private final TokenProvider tokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
 
+<<<<<<< Updated upstream
+=======
+    private final RedisTemplate<String, Object> redisTemplateRT;
+
+>>>>>>> Stashed changes
     @Transactional
     public ReissueDTO.Response reissueJwtToken(ReissueDTO.Request request) throws JsonProcessingException, RefreshFailedException {
         String refreshToken = request.getRefreshToken();
@@ -36,7 +49,13 @@ public class Oauth2Service {
 
         long refreshTokenExpiration = tokenProvider.getRefreshTokenExpirationByManual(refreshToken);
 
+<<<<<<< Updated upstream
         if (refreshTokenExpiration <= 0) {
+=======
+
+        String expiredKey = "expired:" + refreshToken;
+        if (refreshTokenExpiration <= 0 || Boolean.TRUE.equals(redisTemplateRT.hasKey(expiredKey))) {
+>>>>>>> Stashed changes
             throw new RefreshFailedException("Refresh token is expired");
         }
 
@@ -67,4 +86,28 @@ public class Oauth2Service {
                 .build();
     }
 
+<<<<<<< Updated upstream
+=======
+    @Transactional
+    public void logout() {
+        MemberRole memberRole = customUserDetailsService.getCurrentAuthenticatedMemberRole();
+
+        String expiredKey = null;
+        String refreshToken = null;
+
+        if (memberRole == MemberRole.CUSTOMER) {
+            Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
+            refreshToken = customer.getRefreshToken();
+            expiredKey = "expired:" + refreshToken;
+            customer.updateRefreshToken(null);
+        } else if (memberRole == MemberRole.WEDDING_PLANNER) {
+            WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
+            refreshToken = weddingPlanner.getRefreshToken();
+            expiredKey = "expired:" + refreshToken;
+            weddingPlanner.updateRefreshToken(null);
+        }
+        
+        redisTemplateRT.opsForValue().set(expiredKey, "blacklisted", tokenProvider.getRefreshTokenExpiration(refreshToken), TimeUnit.MILLISECONDS);
+    }
+>>>>>>> Stashed changes
 }

--- a/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
+++ b/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
@@ -1,0 +1,68 @@
+package com.example.demo.oauth2.service;
+
+import com.example.demo.enums.member.MemberRole;
+import com.example.demo.jwt.TokenProvider;
+import com.example.demo.member.domain.Customer;
+import com.example.demo.member.domain.WeddingPlanner;
+import com.example.demo.member.service.CustomUserDetailsService;
+import com.example.demo.oauth2.dto.ReissueDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.security.auth.RefreshFailedException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class Oauth2Service {
+
+    private final TokenProvider tokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Transactional
+    public ReissueDTO.Response reissueJwtToken(ReissueDTO.Request request) throws JsonProcessingException, RefreshFailedException {
+        String refreshToken = request.getRefreshToken();
+
+        if (refreshToken == null) {
+            throw new NullPointerException("No refresh token found in request");
+        }
+
+        long refreshTokenExpiration = tokenProvider.getRefreshTokenExpirationByManual(refreshToken);
+
+        if (refreshTokenExpiration <= 0) {
+            throw new RefreshFailedException("Refresh token is expired");
+        }
+
+        String UUID = tokenProvider.getUniqueId(refreshToken);
+
+        MemberRole memberRole = customUserDetailsService.getCurrentAuthenticatedMemberRole();
+
+        String accessToken = null;
+        String newRefreshToken = null;
+
+        if (memberRole == MemberRole.CUSTOMER) {
+            Customer customer = customUserDetailsService.getCurrentAuthenticatedCustomer();
+            accessToken = tokenProvider.createAccessToken(customer.getName(), UUID);
+            newRefreshToken = tokenProvider.createRefreshToken(customer.getName(), UUID);
+            customer.updateRefreshToken(newRefreshToken);
+        } else if (memberRole == MemberRole.WEDDING_PLANNER) {
+            WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
+            accessToken = tokenProvider.createAccessToken(weddingPlanner.getName(), UUID);
+            newRefreshToken = tokenProvider.createRefreshToken(weddingPlanner.getName(), UUID);
+            weddingPlanner.updateRefreshToken(newRefreshToken);
+        }
+        Authentication authentication = customUserDetailsService.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return ReissueDTO.Response.builder()
+                .accessToken(accessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
+
+}

--- a/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
+++ b/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
@@ -32,6 +32,8 @@ public class Oauth2Service {
             throw new NullPointerException("No refresh token found in request");
         }
 
+        tokenProvider.validateRefreshToken(refreshToken);
+
         long refreshTokenExpiration = tokenProvider.getRefreshTokenExpirationByManual(refreshToken);
 
         if (refreshTokenExpiration <= 0) {

--- a/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
+++ b/demo/src/main/java/com/example/demo/oauth2/service/Oauth2Service.java
@@ -41,7 +41,6 @@ public class Oauth2Service {
 
         long refreshTokenExpiration = tokenProvider.getRefreshTokenExpirationByManual(refreshToken);
 
-
         String expiredKey = "expired:" + refreshToken;
         if (refreshTokenExpiration <= 0 || Boolean.TRUE.equals(redisTemplateRT.hasKey(expiredKey))) {
 

--- a/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
+++ b/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
@@ -23,14 +23,14 @@ public class RedisController {
     @GetMapping("/set/all")
     @Operation(summary = "Value가 Set인 모든 데이터 조회")
     public Map<String, Set<Object>> getAllSetValue() {
-        log.info("Getting all set values");
+        log.info("[Redis] Getting all set values");
         return redisService.getAllSetPairs();
     }
 
     @GetMapping("/set/get")
     @Operation(summary = "Value가 Set인 특정 데이터 조회")
     public String getSetValue(@RequestParam String key) {
-        log.info("Getting set value for key: {}", key);
+        log.info("[Redis] Getting set value for key: {}", key);
         String value = redisService.getSetValue(key);
         return value;
     }
@@ -38,21 +38,21 @@ public class RedisController {
     @GetMapping("/set/delete/all")
     @Operation(summary = "Value가 Set인 모든 데이터 삭제")
     public void deleteAllSetValues() {
-        log.info("Deleting all set values for key");
+        log.info("[Redis] Deleting all set values for key");
         redisService.deleteAllSet();
     }
 
     @GetMapping("/every/all")
     @Operation(summary = "모든 데이터 조회")
     public Map<String, Object> getAllData() {
-        log.info("Getting all values");
+        log.info("[Redis] Getting all values");
         return redisService.getAllData();
     }
 
     @GetMapping("/every/delete/all")
     @Operation(summary = "모든 데이터 삭제")
     public void deleteAllData() {
-        log.info("Deleting all values");
+        log.info("[Redis] Deleting all values");
         redisService.deleteAllData();
     }
 

--- a/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
+++ b/demo/src/main/java/com/example/demo/redis/controller/RedisController.java
@@ -1,6 +1,7 @@
 package com.example.demo.redis.controller;
 
 import com.example.demo.redis.service.RedisService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,33 +20,50 @@ public class RedisController {
 
     private final RedisService redisService;
 
-    @GetMapping("/set/get/all")
+    @GetMapping("/set/all")
+    @Operation(summary = "Value가 Set인 모든 데이터 조회")
     public Map<String, Set<Object>> getAllSetValue() {
         log.info("Getting all set values");
         return redisService.getAllSetPairs();
     }
 
-    @GetMapping("/all/exists")
-    public boolean checkExistsValue(@RequestParam String key) {
-        log.info("Checking existence for key: {}", key);
-        boolean exists = redisService.checkExistsValue(redisService.getValue(key));
-        log.info("Existence check for key: {} is: {}", key, exists);
-        return exists;
-    }
-
     @GetMapping("/set/get")
+    @Operation(summary = "Value가 Set인 특정 데이터 조회")
     public String getSetValue(@RequestParam String key) {
         log.info("Getting set value for key: {}", key);
         String value = redisService.getSetValue(key);
         return value;
     }
 
-    @GetMapping("set/delete/all")
+    @GetMapping("/set/delete/all")
+    @Operation(summary = "Value가 Set인 모든 데이터 삭제")
     public void deleteAllSetValues() {
         log.info("Deleting all set values for key");
         redisService.deleteAllSet();
     }
 
+    @GetMapping("/every/all")
+    @Operation(summary = "모든 데이터 조회")
+    public Map<String, Object> getAllData() {
+        log.info("Getting all values");
+        return redisService.getAllData();
+    }
+
+    @GetMapping("/every/delete/all")
+    @Operation(summary = "모든 데이터 삭제")
+    public void deleteAllData() {
+        log.info("Deleting all values");
+        redisService.deleteAllData();
+    }
+
+//     @GetMapping("/all/exists")
+//    public boolean checkExistsValue(@RequestParam String key) {
+//        log.info("Checking existence for key: {}", key);
+//        boolean exists = redisService.checkExistsValue(redisService.getValue(key));
+//        log.info("Existence check for key: {} is: {}", key, exists);
+//        return exists;
+//    }
+//
 //    @PostMapping("/set")
 //    public void setValue(@RequestParam String key, @RequestParam String value) {
 //        log.info("Setting value for key: {}", key);

--- a/demo/src/main/java/com/example/demo/redis/service/RedisService.java
+++ b/demo/src/main/java/com/example/demo/redis/service/RedisService.java
@@ -149,4 +149,29 @@ public class RedisService {
         return allSetPairs;
     }
 
+    // retrieve every data in redis
+    public Map<String, Object> getAllData() {
+        Set<String> allKeys = redisTemplate.keys("*");  // get all keys
+        Map<String, Object> allData = new HashMap<>();  // create a map to store key-value pairs
+
+        if (allKeys != null) {
+            for (String key : allKeys) {
+                Object value = redisTemplate.opsForValue().get(key);  // retrieve value
+                if (value != null) {
+                    allData.put(key, value);  // store the key and its value in the map
+                }
+            }
+        }
+        return allData;
+    }
+
+    // delete every data in redis
+    public void deleteAllData() {
+        Set<String> allKeys = redisTemplate.keys("*");  // get all keys
+        if (allKeys != null) {
+            for (String key : allKeys) {
+                redisTemplate.delete(key);  // delete the key
+            }
+        }
+    }
 }

--- a/demo/src/main/resources/application.yml
+++ b/demo/src/main/resources/application.yml
@@ -33,8 +33,8 @@ kakao:
   client_id_native: ${KAKAO_CLIENT_ID_NATIVE}
 
 google:
-  client-id: ${GOOGLE_CLIENT_ID_WEB}
-  client-secret: ${GOOGLE_CLIENT_SECRET_WEB}
+  client-id-android: ${GOOGLE_CLIENT_ID_ANDROID}}
+  client-id-ios: ${GOOGLE_CLIENT_ID_IOS}
 
 ---
 


### PR DESCRIPTION
### PR 요약
OAuth2 소셜 로그인 구현

### 변경 사항
- Refresh Token Rotation 전략 채택하여 AT, RT 재발급
- Kakao, Google 소셜 로그인

### Remain TODO
- Admin JWT 발급 필요
- Google login 시 name field null로 들어오는 것 해결 필요
- Redis 관리 시 자료형 상관 없이 조회할 수 있는 기능 필요
-  Invalid AT 헤더로 STOMP Connect 시, DISCONNECT 자동으로 되는지 확인 필요

### Related PR
- #161 
- #162 
- #163 
- #164 
- #165 