### PR TITLE
Refactor/Migrate search implementation from opensearch to jpa

### DIFF
--- a/demo/src/main/java/com/example/demo/portfolio/mapper/PortfolioMapper.java
+++ b/demo/src/main/java/com/example/demo/portfolio/mapper/PortfolioMapper.java
@@ -15,7 +15,7 @@ public interface PortfolioMapper {
     Portfolio requestToEntity(PortfolioDTO.Request portfolioRequest);
 
     PortfolioDTO.Response entityToResponse(Portfolio portfolio);
-    
+
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     @Mapping(target = "id", ignore = true)
     Portfolio updateFromRequest(PortfolioDTO.Request portfolioRequest, @MappingTarget Portfolio portfolio);
@@ -26,5 +26,5 @@ public interface PortfolioMapper {
 
     PortfolioSearchDTO.Response requestToSearchResponse(PortfolioSearchDTO.Request request);
 
-
+    PortfolioSearchDTO.Response entityToSearchResponse(Portfolio portfolio);
 }

--- a/demo/src/main/java/com/example/demo/portfolio/repository/PortfolioRepository.java
+++ b/demo/src/main/java/com/example/demo/portfolio/repository/PortfolioRepository.java
@@ -36,4 +36,11 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     void increaseViewCount(@Param("id") Long id);
 
     List<Portfolio> findTop5ByOrderByViewCountDesc();
+
+    @Query(value = "SELECT DISTINCT p.* FROM portfolio p JOIN portfolio_services ps ON p.portfolio_id = ps.portfolio_id " +
+            "WHERE ps.service_value LIKE %:keyword% OR p.planner_name LIKE %:keyword% OR " +
+            "p.organization LIKE %:keyword% OR p.introduction LIKE %:keyword%",
+            nativeQuery = true)
+    List<Portfolio> searchByKeyword(@Param("keyword") String keyword);
+    
 }

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioSearchService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioSearchService.java
@@ -31,10 +31,9 @@ public class PortfolioSearchService {
             log.info("Searching documents with keyword: {}", keyword);
 
             List<Portfolio> portfolios = portfolioRepository.searchByKeyword(keyword);
-            
+
             for (Portfolio portfolio : portfolios) {
-                PortfolioSearchDTO.Request request = portfolioMapper.entityToSearchRequest(portfolio);
-                PortfolioSearchDTO.Response response = portfolioMapper.requestToSearchResponse(request);
+                PortfolioSearchDTO.Response response = portfolioMapper.entityToSearchResponse(portfolio);
                 response.setIsWishListed(isWishListed(portfolio.getId()));
                 resultList.add(response);
             }

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioSearchService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioSearchService.java
@@ -5,15 +5,10 @@ import com.example.demo.member.service.CustomUserDetailsService;
 import com.example.demo.portfolio.domain.Portfolio;
 import com.example.demo.portfolio.dto.PortfolioSearchDTO;
 import com.example.demo.portfolio.mapper.PortfolioMapper;
+import com.example.demo.portfolio.repository.PortfolioRepository;
 import com.example.demo.wishlist.repository.WishListRepository;
-import com.example.demo.wishlist.service.WishListService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
-import org.opensearch.client.opensearch.core.*;
-import org.opensearch.client.opensearch.core.search.Hit;
-import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -27,29 +22,22 @@ public class PortfolioSearchService {
     private final PortfolioMapper portfolioMapper;
     private final CustomUserDetailsService memberService;
     private final WishListRepository wishListRepository;
+    private final PortfolioRepository portfolioRepository;
 
 
     public List<PortfolioSearchDTO.Response> search(String keyword) {
         List<PortfolioSearchDTO.Response> resultList = new ArrayList<>();
         try {
             log.info("Searching documents with keyword: {}", keyword);
-            List<String> sourceList = List.of("services", "plannerName", "organization", "introduction");
 
-            // TODO ====================== JPA migration =============================
-
-//            SearchRequest request = buildSearchRequest(indexName, keyword, sourceList);
-//
-//            SearchResponse<PortfolioSearchDTO.Request> response = openSearchClient.search(request, PortfolioSearchDTO.Request.class);
-//
-//
-//            List<Hit<PortfolioSearchDTO.Request>> hits = response.hits().hits();
-//            for (Hit<PortfolioSearchDTO.Request> hit : hits) {
-//                PortfolioSearchDTO.Response searchResponse = portfolioMapper.requestToSearchResponse(hit.source());
-//                searchResponse.setIsWishListed(isWishListed(searchResponse.getId()));
-//                resultList.add(searchResponse);
-//            }
-
-            // TODO ===================================================================
+            List<Portfolio> portfolios = portfolioRepository.searchByKeyword(keyword);
+            
+            for (Portfolio portfolio : portfolios) {
+                PortfolioSearchDTO.Request request = portfolioMapper.entityToSearchRequest(portfolio);
+                PortfolioSearchDTO.Response response = portfolioMapper.requestToSearchResponse(request);
+                response.setIsWishListed(isWishListed(portfolio.getId()));
+                resultList.add(response);
+            }
 
             log.info("Found {} documents with keyword: {}", resultList.size(), keyword);
         } catch (Exception e) {


### PR DESCRIPTION
### PR 요약
검색 기능 : OpenSearch 사용하던 방식에서 JPA로 변경

### 변경 사항
- `Native Query` 사용하여 검색하도록 변경

### 참고 사항
