### PR TITLE
Refactor/Append various prompting engineering techniques

### DIFF
--- a/demo/src/main/java/com/example/demo/chat/controller/ChatBotController.java
+++ b/demo/src/main/java/com/example/demo/chat/controller/ChatBotController.java
@@ -1,10 +1,10 @@
 package com.example.demo.chat.controller;
 
+import com.example.demo.chat.service.ChatBotService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,17 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "chatbot", description = "챗봇 API")
 public class ChatBotController {
 
-    private final ChatClient chatClient;
+    private final ChatBotService chatBotService;
 
     @PostMapping("/test")
     @Operation(summary = "테스트")
     public ResponseEntity<String> chatWithChatBot(@RequestBody String message) {
 
-        String answer = chatClient.prompt()
-                .system("넌 이제부터 한국의 웨딩플래너 전문가야. 추정치를 바탕으로 확실한 답변을 해줘.")
-                .user(message)
-                .call()
-                .content();
+        String answer = chatBotService.getAnswer(message);
 
         return ResponseEntity.status(200).body(answer);
     }

--- a/demo/src/main/java/com/example/demo/chat/domain/Question.java
+++ b/demo/src/main/java/com/example/demo/chat/domain/Question.java
@@ -1,0 +1,27 @@
+package com.example.demo.chat.domain;
+
+import com.example.demo.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Where;
+
+@Getter
+@Setter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Where(clause = "is_deleted = false")
+public class Question extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_id")
+    private Long id;
+
+    @Builder.Default
+    private boolean isDeleted = Boolean.FALSE;
+
+    private String question;
+    private String answer;
+}

--- a/demo/src/main/java/com/example/demo/chat/repository/QuestionRepository.java
+++ b/demo/src/main/java/com/example/demo/chat/repository/QuestionRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.chat.repository;
+
+import com.example.demo.chat.domain.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/demo/src/main/java/com/example/demo/chat/service/ChatBotService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatBotService.java
@@ -16,11 +16,11 @@ public class ChatBotService {
 
     private final QuestionRepository questionRepository;
 
-    private final String PERSONA_PROMPTING = "넌 한국의 웨딩플래너 전문가야. 질문자의 의도를 분석해서 제안하는 답변을 해줘.";
-    private final String CHAIN_OF_THOUGHT = "우선 지금까지 학습된 커뮤니티 질의응답 데이터를 바탕으로 비슷한 질문이 있는지 찾아보고, 댓글 중 적절한 답변을 정리해서 추려줘.";
-    private final String RULE_BASED_PROMPTING = "비속어는 무조건 필터링 혹은 순화해서 표현해야 해.";
-    private final String ADDITIONAL_INFORMATION = "질문자가 원하는 답변을 찾지 못했을 경우에는 '질문을 이해하지 못 했어요. 다시 질문해주세요.'라고 말해줘." +
-            "사용자가 '고마워요' 등 대화를 종료하는 말을 하면, '도움이 필요할 때 언제든지 말씀해주세요!' 와 같은 답변으로 대화를 자연스럽게 끝맺어줘.";
+    private static final String PERSONA_PROMPTING = "넌 한국의 웨딩플래너 전문가야. 질문자의 의도를 분석해서 제안하는 답변을 해줘.";
+    private static final String CHAIN_OF_THOUGHT = "우선 지금까지 학습된 커뮤니티 질의응답 데이터를 바탕으로 비슷한 질문이 있는지 찾아보고, 댓글 중 적절한 답변을 정리해서 추려줘.";
+    private static final String RULE_BASED_PROMPTING = "비속어는 무조건 필터링 혹은 순화해서 표현해야 해. 웨딩과 너무 연관 없는 질문은 '웨딩에 대한 질문이 아닌 것 같아요. 다른 질문이 있으신가요?'와 같은 답변으로 대화를 이어가야 해.";
+    private static final String ADDITIONAL_INFORMATION = "질문자가 원하는 답변을 찾지 못했을 경우에는 '질문을 이해하지 못 했어요. 다시 질문해주세요.'라고 말해줘." +
+            "혹은 사용자가 '고마워요' 등 대화를 종료하는 말을 하면, '도움이 필요할 때 언제든지 말씀해주세요!' 와 같은 답변으로 대화를 자연스럽게 끝맺어줘.";
 
     public String getAnswer(String message) {
         String answer = chatClient.prompt()
@@ -40,7 +40,7 @@ public class ChatBotService {
                 .build();
 
         questionRepository.save(question);
-        
+
         return answer;
     }
 }

--- a/demo/src/main/java/com/example/demo/chat/service/ChatBotService.java
+++ b/demo/src/main/java/com/example/demo/chat/service/ChatBotService.java
@@ -1,0 +1,46 @@
+package com.example.demo.chat.service;
+
+import com.example.demo.chat.domain.Question;
+import com.example.demo.chat.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatBotService {
+
+    private final ChatClient chatClient;
+
+    private final QuestionRepository questionRepository;
+
+    private final String PERSONA_PROMPTING = "넌 한국의 웨딩플래너 전문가야. 질문자의 의도를 분석해서 제안하는 답변을 해줘.";
+    private final String CHAIN_OF_THOUGHT = "우선 지금까지 학습된 커뮤니티 질의응답 데이터를 바탕으로 비슷한 질문이 있는지 찾아보고, 댓글 중 적절한 답변을 정리해서 추려줘.";
+    private final String RULE_BASED_PROMPTING = "비속어는 무조건 필터링 혹은 순화해서 표현해야 해.";
+    private final String ADDITIONAL_INFORMATION = "질문자가 원하는 답변을 찾지 못했을 경우에는 '질문을 이해하지 못 했어요. 다시 질문해주세요.'라고 말해줘." +
+            "사용자가 '고마워요' 등 대화를 종료하는 말을 하면, '도움이 필요할 때 언제든지 말씀해주세요!' 와 같은 답변으로 대화를 자연스럽게 끝맺어줘.";
+
+    public String getAnswer(String message) {
+        String answer = chatClient.prompt()
+                .system(
+                        PERSONA_PROMPTING + "\n" +
+                                CHAIN_OF_THOUGHT + "\n" +
+                                RULE_BASED_PROMPTING + "\n" +
+                                ADDITIONAL_INFORMATION
+                )
+                .user(message)
+                .call()
+                .content();
+
+        Question question = Question.builder()
+                .question(message)
+                .answer(answer)
+                .build();
+
+        questionRepository.save(question);
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
### PR 요약
챗봇에 Prompt를 추가하여 챗봇 역할에 적합한 대답을 할 수 있도록 구성했습니다.

### 변경 사항
- `PERSONA_PROMPTING` : "넌 한국의 웨딩플래너 전문가야. 질문자의 의도를 분석해서 제안하는 답변을 해줘."
- `CHAIN_OF_THOUGHT` : "우선 지금까지 학습된 커뮤니티 질의응답 데이터를 바탕으로 비슷한 질문이 있는지 찾아보고, 댓글 중 적절한 답변을 정리해서 추려줘."
- `RULE_BASED_PROMPTING` : "비속어는 무조건 필터링 혹은 순화해서 표현해야 해."
- `ADDITIONAL_INFORMATION` : "질문자가 원하는 답변을 찾지 못했을 경우에는 '질문을 이해하지 못 했어요. 다시 질문해주세요.'라고 말해줘.", "사용자가 '고마워요' 등 대화를 종료하는 말을 하면, '도움이 필요할 때 언제든지 말씀해주세요!' 와 같은 답변으로 대화를 자연스럽게 끝맺어줘."

### Related PR
- #173 
