### PR TITLE
Refactor/Throw portfolio not found custom error with 409 conflict

### DIFF
--- a/demo/src/main/java/com/example/demo/error/ErrorCode.java
+++ b/demo/src/main/java/com/example/demo/error/ErrorCode.java
@@ -85,7 +85,10 @@ public enum ErrorCode {
     REFRESH_TOKEN_EXPIRED_ERROR(401, "G015", "Refresh Token Expired Exception"),
 
     // unauthorized
-    UNAUTHORIZED_ERROR(401, "G016", "Unauthorized Exception");
+    UNAUTHORIZED_ERROR(401, "G016", "Unauthorized Exception"),
+
+    // portfolio not found
+    PORTFOLIO_NOT_FOUND_ERROR(409, "G017", "Portfolio Not Found Exception");
 
     /**
      * ******************************* Error Code Constructor ***************************************

--- a/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
+++ b/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.demo.error;
 
 import com.example.demo.discord.DiscordMessageProvider;
 import com.example.demo.enums.member.MemberRole;
+import com.example.demo.error.custom.PortfolioNotFoundException;
 import com.example.demo.member.service.CustomUserDetailsService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.gson.JsonParseException;
@@ -206,6 +207,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
         return buildErrorResponseAndSendAlert(ex, ErrorCode.UNAUTHORIZED_ERROR, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(PortfolioNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handlePortfolioNotFoundException(PortfolioNotFoundException ex) {
+        return buildErrorResponseAndSendAlert(ex, ErrorCode.PORTFOLIO_NOT_FOUND_ERROR, HttpStatus.CONFLICT);
     }
 
     // ==================================================================================================================

--- a/demo/src/main/java/com/example/demo/error/custom/PortfolioNotFoundException.java
+++ b/demo/src/main/java/com/example/demo/error/custom/PortfolioNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.demo.error.custom;
+
+public class PortfolioNotFoundException extends RuntimeException {
+
+    public PortfolioNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
+++ b/demo/src/main/java/com/example/demo/portfolio/service/PortfolioService.java
@@ -2,6 +2,7 @@ package com.example.demo.portfolio.service;
 
 import com.example.demo.config.S3Uploader;
 import com.example.demo.enums.review.RadarKey;
+import com.example.demo.error.custom.PortfolioNotFoundException;
 import com.example.demo.member.domain.WeddingPlanner;
 import com.example.demo.member.mapper.WeddingPlannerMapper;
 import com.example.demo.member.repository.WeddingPlannerRepository;
@@ -346,7 +347,7 @@ public class PortfolioService {
         WeddingPlanner weddingPlanner = customUserDetailsService.getCurrentAuthenticatedWeddingPlanner();
         Portfolio portfolio = weddingPlanner.getPortfolio();
         if (portfolio == null) {
-            throw new RuntimeException("Portfolio not found");
+            throw new PortfolioNotFoundException("Portfolio not found");
         }
         PortfolioDTO.Response portfolioResponse = portfolioMapper.entityToResponse(portfolio);
         return portfolioResponse;


### PR DESCRIPTION
### PR 요약
웨딩플래너의 포트폴리오가 작성되지 않았을 때(최초 가입 후), `409 CONFLICT`를 리턴하여 프론트에서 처리하도록 변경

### 변경 사항
- 기존의 런타임에러를 409 CONFLICT ErrorCode로 반환

### 참고 사항
