### PR TITLE
Refactor/Throw invalid exception when token damaged  @yeong-hwan

### DIFF
--- a/demo/src/main/java/com/example/demo/config/JwtAuthenticationFilter.java
+++ b/demo/src/main/java/com/example/demo/config/JwtAuthenticationFilter.java
@@ -1,12 +1,15 @@
 package com.example.demo.config;
 
+import com.example.demo.jwt.JwtValidator;
 import com.example.demo.member.service.CustomUserDetailsService;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -15,6 +18,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 
 @Component
@@ -22,6 +26,8 @@ import java.io.IOException;
 class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final CustomUserDetailsService customUserDetailsService;
+    private final JwtValidator jwtValidator;
+
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
@@ -30,6 +36,15 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String accessToken = resolveToken(request);
+
+        // validate JWT token
+        if (accessToken != null && jwtValidator.isValidToken(accessToken)) {
+            Authentication authentication = getAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
 
         if (StringUtils.hasText(accessToken)) {
             try {
@@ -45,6 +60,7 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
                 logger.error("Could not set user authentication in security context", e);
             }
         }
+
         filterChain.doFilter(request, response);
     }
 
@@ -54,5 +70,13 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    private Authentication getAuthentication(String token) {
+        // 토큰에서 사용자 정보 추출 및 인증 객체 생성
+        Claims claims = jwtValidator.getTokenClaims(token);
+        String username = claims.getSubject();
+        // 권한 또는 사용자 정보 설정
+        return new UsernamePasswordAuthenticationToken(username, null, new ArrayList<>());
     }
 }

--- a/demo/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -29,21 +29,17 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
-                                .requestMatchers("/**").permitAll() // wildcard
-                                .requestMatchers("/api/v1/auth/shared/create").permitAll()
-                                .requestMatchers("/", "/index.html", "/weddingplanner-chat.html", "/customer-chat.html", "/swagger-ui/*", "/swagger-resources/**", "/v3/api-docs/**", "/actuator/**", "/metrics/**").permitAll()
-                                .requestMatchers("/api/v1/*/shared/**").hasAnyRole("CUSTOMER", "WEDDING_PLANNER")
-                                .requestMatchers("/api/v1/*/weddingplanner/**").hasRole("WEDDING_PLANNER")
-                                .requestMatchers("/api/v1/*/customer/**").hasRole("CUSTOMER")
-                                .requestMatchers("/stomp/**").permitAll()
-                                .requestMatchers("/kakao.html", "/login.html").permitAll()
-                                .anyRequest().authenticated()
-//                )
-//                .oauth2Login(ouath2 -> ouath2
-//                        .loginPage("/kakao")
-//                        .defaultSuccessUrl("/home", true)
-//                        .failureUrl("/login?error=true")
-//                        .permitAll()
+                        .requestMatchers("/**").permitAll() // wildcard
+                        .requestMatchers("/stomp/**").permitAll()
+                        .requestMatchers("/api/v1/auth/shared/create").permitAll()
+                        .requestMatchers("/", "/index.html", "/weddingplanner-chat.html", "/customer-chat.html", "/swagger-ui/*", "/swagger-resources/**", "/v3/api-docs/**", "/actuator/**", "/metrics/**").permitAll()
+                        .requestMatchers("/api/v1/oauth2/**").permitAll()
+                        .requestMatchers("/api/v1/*/shared/**").hasAnyRole("CUSTOMER", "WEDDING_PLANNER")
+                        .requestMatchers("/api/v1/*/weddingplanner/**").hasRole("WEDDING_PLANNER")
+                        .requestMatchers("/api/v1/*/customer/**").hasRole("CUSTOMER")
+                        .requestMatchers("/stomp/**").permitAll()
+                        .requestMatchers("/kakao.html", "/login.html").permitAll()
+                        .anyRequest().authenticated()
                 );
         return http.build();
     }

--- a/demo/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -4,11 +4,13 @@ import com.example.demo.member.service.CustomUserDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -30,17 +32,25 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/**").permitAll() // wildcard
+                        .requestMatchers("/api/v1/admin/**").permitAll()
+                        .requestMatchers("/api/v1/oauth2/**").permitAll()
                         .requestMatchers("/stomp/**").permitAll()
                         .requestMatchers("/api/v1/auth/shared/create").permitAll()
                         .requestMatchers("/", "/index.html", "/weddingplanner-chat.html", "/customer-chat.html", "/swagger-ui/*", "/swagger-resources/**", "/v3/api-docs/**", "/actuator/**", "/metrics/**").permitAll()
-                        .requestMatchers("/api/v1/oauth2/**").permitAll()
                         .requestMatchers("/api/v1/*/shared/**").hasAnyRole("CUSTOMER", "WEDDING_PLANNER")
                         .requestMatchers("/api/v1/*/weddingplanner/**").hasRole("WEDDING_PLANNER")
                         .requestMatchers("/api/v1/*/customer/**").hasRole("CUSTOMER")
                         .requestMatchers("/stomp/**").permitAll()
-                        .requestMatchers("/kakao.html", "/login.html").permitAll()
                         .anyRequest().authenticated()
+
+                )
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling.authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Unauthorized");
+                        })
                 );
+
+
         return http.build();
     }
 
@@ -51,4 +61,12 @@ public class SecurityConfig {
                 .userDetailsService(customUserDetailsService);
         return http.getSharedObject(AuthenticationManager.class);
     }
+
+    @Bean
+    public AuthenticationEntryPoint unauthorizedEntryPoint() {
+        return (request, response, authException) -> {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Unauthorized");
+        };
+    }
+
 }

--- a/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
+++ b/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.demo.error;
 
 import com.example.demo.discord.DiscordMessageProvider;
 import com.example.demo.enums.member.MemberRole;
+import com.example.demo.error.custom.InvalidJwtAuthenticationException;
 import com.example.demo.error.custom.PortfolioNotFoundException;
 import com.example.demo.member.service.CustomUserDetailsService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,6 +27,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 
 import javax.security.auth.RefreshFailedException;
 import java.io.IOException;
+import java.security.SignatureException;
 
 @Slf4j
 @RestControllerAdvice
@@ -213,6 +215,17 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handlePortfolioNotFoundException(PortfolioNotFoundException ex) {
         return buildErrorResponseAndSendAlert(ex, ErrorCode.PORTFOLIO_NOT_FOUND_ERROR, HttpStatus.CONFLICT);
     }
+
+    @ExceptionHandler(SignatureException.class)
+    protected ResponseEntity<ErrorResponse> handleSignatureException(SignatureException ex) {
+        return buildErrorResponseAndSendAlert(ex, ErrorCode.UNAUTHORIZED_ERROR, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(InvalidJwtAuthenticationException.class)
+    protected ResponseEntity<ErrorResponse> handleInvalidJwtAuthentication(InvalidJwtAuthenticationException ex) {
+        return buildErrorResponseAndSendAlert(ex, ErrorCode.UNAUTHORIZED_ERROR, HttpStatus.UNAUTHORIZED);
+    }
+
 
     // ==================================================================================================================
 

--- a/demo/src/main/java/com/example/demo/error/custom/InvalidJwtAuthenticationException.java
+++ b/demo/src/main/java/com/example/demo/error/custom/InvalidJwtAuthenticationException.java
@@ -1,0 +1,7 @@
+package com.example.demo.error.custom;
+
+public class InvalidJwtAuthenticationException extends RuntimeException {
+    public InvalidJwtAuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/demo/src/main/java/com/example/demo/error/custom/UnauthorizedException.java
+++ b/demo/src/main/java/com/example/demo/error/custom/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.example.demo.error.custom;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/demo/src/main/java/com/example/demo/jwt/JwtValidator.java
+++ b/demo/src/main/java/com/example/demo/jwt/JwtValidator.java
@@ -1,0 +1,79 @@
+package com.example.demo.jwt;
+
+import com.example.demo.error.custom.InvalidJwtAuthenticationException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtValidator {
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    public Map<String, String> parseHeaders(String token) throws JsonProcessingException {
+        String header = token.split("\\.")[0];
+        return objectMapper.readValue(decodeHeader(header), Map.class);
+    }
+
+    public String decodeHeader(String token) {
+        return new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
+    }
+
+    public Claims getTokenClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8)) // 비밀 키 사용
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public boolean validateSignature(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8)) // 비밀 키 사용
+                    .build()
+                    .parseClaimsJws(token);
+            return true; // 시그니처 검증 성공
+        } catch (io.jsonwebtoken.security.SignatureException e) {
+            // SignatureException이 발생한 경우 401 응답을 위해 false를 반환
+            log.warn("Invalid JWT signature");
+            throw new InvalidJwtAuthenticationException("Invalid JWT signature");
+        } catch (JwtException e) {
+            // 기타 JwtException 처리
+            log.warn("JWT validation error");
+            throw new InvalidJwtAuthenticationException("JWT validation error");
+        }
+    }
+
+
+    public boolean validatePayload(String token) {
+        try {
+            Claims claims = getTokenClaims(token);
+            // 페이로드 유효성 검증 로직 추가 (예: 만료 시간 확인)
+            Date expiration = claims.getExpiration();
+            return expiration != null && expiration.after(new Date()); // 만료 시간 검증
+        } catch (Exception e) {
+            return false; // 페이로드 검증 실패
+        }
+    }
+
+    public boolean isValidToken(String token) {
+        return validateSignature(token) && validatePayload(token);
+    }
+}


### PR DESCRIPTION
### PR 요약
JWT 토큰의 payload, signature에 대한 유효성 검사 및 에러 처리

### 변경 사항
- 토큰 손상 시 `InvalidJwtAuthenticationException(401)` 커스텀 에러 반환

### 참고 사항
- 서블릿이 글로벌 익셉션 앞단에서 Runtime 에러를 터트리는 것을 우회하기 위해 앞단에서 `Unauthorized Error` Ealry 리턴