### PR TITLE
Feat/Implement oauth2 login/revoke by apple

### DIFF
--- a/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
+++ b/demo/src/main/java/com/example/demo/error/GlobalExceptionHandler.java
@@ -198,6 +198,12 @@ public class GlobalExceptionHandler {
         return buildErrorResponseAndSendAlert(ex, ErrorCode.FEIGN_CLIENT_ERROR, HttpStatus.BAD_REQUEST);
     }
 
+    /**
+     * [Exception] JWT 토큰이 유효하지 않은 경우
+     *
+     * @param ex MalformedJwtException
+     * @return ResponseEntity<ErrorResponse>
+     */
     @ExceptionHandler(MalformedJwtException.class)
     protected ResponseEntity<ErrorResponse> handleMalformedJwtException(MalformedJwtException ex) {
         return buildErrorResponseAndSendAlert(ex, ErrorCode.UNAUTHORIZED_ERROR, HttpStatus.UNAUTHORIZED);

--- a/demo/src/main/java/com/example/demo/jwt/JwtValidator.java
+++ b/demo/src/main/java/com/example/demo/jwt/JwtValidator.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
 import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
@@ -35,6 +36,7 @@ public class JwtValidator {
         return new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
     }
 
+    // 기존 비밀 키 기반의 getTokenClaims 메서드는 그대로 유지
     public Claims getTokenClaims(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8)) // 비밀 키 사용
@@ -43,29 +45,34 @@ public class JwtValidator {
                 .getBody();
     }
 
-    public boolean validateSignature(String token) {
+    // 공개 키 기반의 getTokenClaims 메서드 추가
+    public Claims getTokenClaims(String token, PublicKey publicKey) {
+        return Jwts.parserBuilder()
+                .setSigningKey(publicKey) // 공개 키 사용
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public boolean validateSignature(String token, PublicKey publicKey) {
         try {
             Jwts.parserBuilder()
-                    .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8)) // 비밀 키 사용
+                    .setSigningKey(publicKey) // 공개 키 사용
                     .build()
                     .parseClaimsJws(token);
             return true; // 시그니처 검증 성공
         } catch (io.jsonwebtoken.security.SignatureException e) {
-            // SignatureException이 발생한 경우 401 응답을 위해 false를 반환
             log.warn("Invalid JWT signature");
             throw new InvalidJwtAuthenticationException("Invalid JWT signature");
         } catch (JwtException e) {
-            // 기타 JwtException 처리
             log.warn("JWT validation error");
             throw new InvalidJwtAuthenticationException("JWT validation error");
         }
     }
 
-
     public boolean validatePayload(String token) {
         try {
             Claims claims = getTokenClaims(token);
-            // 페이로드 유효성 검증 로직 추가 (예: 만료 시간 확인)
             Date expiration = claims.getExpiration();
             return expiration != null && expiration.after(new Date()); // 만료 시간 검증
         } catch (Exception e) {
@@ -73,7 +80,7 @@ public class JwtValidator {
         }
     }
 
-    public boolean isValidToken(String token) {
-        return validateSignature(token) && validatePayload(token);
+    public boolean isValidToken(String token, PublicKey publicKey) {
+        return validateSignature(token, publicKey) && validatePayload(token);
     }
 }

--- a/demo/src/main/java/com/example/demo/oauth2/apple/domain/AppleRefreshToken.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/domain/AppleRefreshToken.java
@@ -19,6 +19,8 @@ public class AppleRefreshToken extends BaseTimeEntity {
 
     private Long userId;
 
+    private String memberRole;
+
     private String refreshToken;
 
 }

--- a/demo/src/main/java/com/example/demo/oauth2/apple/domain/AppleRefreshToken.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/domain/AppleRefreshToken.java
@@ -1,0 +1,24 @@
+package com.example.demo.oauth2.apple.domain;
+
+import com.example.demo.base.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AppleRefreshToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "apple_refresh_token_id")
+    private Long id;
+
+    private Long userId;
+
+    private String refreshToken;
+
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/dto/AppleLoginDTO.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/dto/AppleLoginDTO.java
@@ -1,0 +1,42 @@
+package com.example.demo.oauth2.apple.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class AppleLoginDTO {
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String appleIdToken;
+
+        @Schema(type = "string", example = "dslafjkdsrtjlejldfkajlasljdf")
+        private String authorizationCode;
+
+        @Schema(type = "string", example = "WEDDING_PLANNER")
+        private String role;
+    }
+
+    @Setter
+    @Getter
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String accessToken;
+
+        @Schema(type = "string", example = "asd2221edqsdqwd23e")
+        private String refreshToken;
+
+        @Schema(type = "string", example = "kakao-asdd2d12d")
+        private String UUID;
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/dto/ApplePublicKey.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/dto/ApplePublicKey.java
@@ -1,0 +1,10 @@
+package com.example.demo.oauth2.apple.dto;
+
+public record ApplePublicKey(
+        String kty,
+        String kid,
+        String alg,
+        String n,
+        String e
+) {
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/dto/ApplePublicKeyResponse.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/dto/ApplePublicKeyResponse.java
@@ -1,0 +1,15 @@
+package com.example.demo.oauth2.apple.dto;
+
+import org.apache.http.auth.AuthenticationException;
+
+import java.util.List;
+
+public record ApplePublicKeyResponse(List<ApplePublicKey> keys) {
+
+    public ApplePublicKey getMatchedKey(String kid, String alg) throws AuthenticationException {
+        return keys.stream()
+                .filter(key -> key.kid().equals(kid) && key.alg().equals(alg))
+                .findAny()
+                .orElseThrow(AuthenticationException::new);
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/dto/AppleRevokeDTO.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/dto/AppleRevokeDTO.java
@@ -1,0 +1,14 @@
+package com.example.demo.oauth2.apple.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+public class AppleRevokeDTO {
+
+    @Schema(type = "long", example = "3")
+    private Long userId;
+
+    @Schema(type = "string", example = "WEDDING_PLANNER")
+    private String memberRole;
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/dto/AppleTokenResponse.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/dto/AppleTokenResponse.java
@@ -1,0 +1,13 @@
+package com.example.demo.oauth2.apple.dto;
+
+import lombok.Data;
+
+@Data
+public class AppleTokenResponse {
+    private String access_token;
+    private long expires_in;
+    private String id_token;
+    private String refresh_token;
+    private String token_type;
+    private String error;
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/dto/AppleUserInfoResponseDTO.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/dto/AppleUserInfoResponseDTO.java
@@ -1,0 +1,21 @@
+package com.example.demo.oauth2.apple.dto;
+
+import lombok.Data;
+
+
+@Data
+public class AppleUserInfoResponseDTO {
+    private String iss;
+    private String aud;
+    private String sub;
+    private String email;
+    private boolean email_verified;
+    private long exp;
+    private long iat;
+    private String nonce;
+    private boolean nonce_supported;
+
+    private String given_name;
+    private String family_name;
+    private String authorizationCode;
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/repository/AppleRefreshTokenRepository.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/repository/AppleRefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.example.demo.oauth2.apple.repository;
+
+import com.example.demo.oauth2.apple.domain.AppleRefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AppleRefreshTokenRepository extends JpaRepository<AppleRefreshToken, Long> {
+    Optional<AppleRefreshToken> findByUserId(Long userId);
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/repository/AppleRefreshTokenRepository.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/repository/AppleRefreshTokenRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AppleRefreshTokenRepository extends JpaRepository<AppleRefreshToken, Long> {
-    Optional<AppleRefreshToken> findByUserId(Long userId);
+    Optional<AppleRefreshToken> findByUserIdAndMemberRole(Long userId, String memberRole);
 }

--- a/demo/src/main/java/com/example/demo/oauth2/apple/service/AppleKeyGenerator.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/service/AppleKeyGenerator.java
@@ -1,0 +1,78 @@
+package com.example.demo.oauth2.apple.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.security.PrivateKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AppleKeyGenerator {
+
+    //    @Value("${oauth.apple.url.public-keys}")
+//    private String applePublicKeysUrl;
+    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys"; // Apple 공개키 URL
+
+    @Value("${apple.kid}")
+    private String kid;
+
+    @Value("${apple.team-id}")
+    private String teamId;
+
+    @Value("${apple.app-id}")
+    private String appId;
+
+    @Value("${apple.private-key}")
+    private String privateKey;
+
+    /**
+     * Apple client secret 을 생성한다.
+     *
+     * @return client_secret JWT
+     * @throws IOException
+     */
+    public String getClientSecret() throws IOException {
+        Date expirationDate = Date.from(LocalDateTime.now().plusDays(30).atZone(ZoneId.systemDefault()).toInstant());
+
+        return Jwts.builder()
+                .setHeaderParam("kid", kid)
+                .setHeaderParam("alg", "ES256")
+                .setIssuer(teamId)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(expirationDate)
+                .setAudience("https://appleid.apple.com")
+                .setSubject(appId)
+                .signWith(getPrivateKey(), SignatureAlgorithm.ES256) // 수정된 부분
+                .compact();
+    }
+
+    /**
+     * apple private 키를 반환한다.
+     *
+     * @return
+     * @throws IOException
+     */
+    private PrivateKey getPrivateKey() throws IOException {
+        try {
+            Reader pemReader = new StringReader(privateKey.replace("\\n", "\n"));
+            PEMParser pemParser = new PEMParser(pemReader);
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            PrivateKeyInfo object = (PrivateKeyInfo) pemParser.readObject();
+            return converter.getPrivateKey(object);
+        } catch (IOException e) {
+            throw new IOException("Failed to read private key", e);
+        }
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/service/ApplePublicKeyGenerator.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/service/ApplePublicKeyGenerator.java
@@ -1,0 +1,41 @@
+package com.example.demo.oauth2.apple.service;
+
+import com.example.demo.oauth2.apple.dto.ApplePublicKey;
+import com.example.demo.oauth2.apple.dto.ApplePublicKeyResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ApplePublicKeyGenerator {
+    public PublicKey generatePublicKey(Map<String, String> tokenHeaders,
+                                       ApplePublicKeyResponse applePublicKeys)
+            throws AuthenticationException, NoSuchAlgorithmException, InvalidKeySpecException, org.apache.http.auth.AuthenticationException {
+        ApplePublicKey publicKey = applePublicKeys.getMatchedKey(tokenHeaders.get("kid"),
+                tokenHeaders.get("alg"));
+
+        return getPublicKey(publicKey);
+    }
+
+    private PublicKey getPublicKey(ApplePublicKey publicKey)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        byte[] nBytes = Base64.getUrlDecoder().decode(publicKey.n());
+        byte[] eBytes = Base64.getUrlDecoder().decode(publicKey.e());
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(new BigInteger(1, nBytes),
+                new BigInteger(1, eBytes));
+
+        KeyFactory keyFactory = KeyFactory.getInstance(publicKey.kty());
+        return keyFactory.generatePublic(publicKeySpec);
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/apple/service/AppleService.java
+++ b/demo/src/main/java/com/example/demo/oauth2/apple/service/AppleService.java
@@ -1,0 +1,146 @@
+package com.example.demo.oauth2.apple.service;
+
+import com.example.demo.jwt.JwtValidator;
+import com.example.demo.oauth2.apple.dto.ApplePublicKeyResponse;
+import com.example.demo.oauth2.apple.dto.AppleTokenResponse;
+import com.example.demo.oauth2.apple.dto.AppleUserInfoResponseDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.MalformedJwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleService {
+
+    private final JwtValidator jwtValidator;
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final AppleKeyGenerator appleKeyGenerator;
+
+    RestClient restClient = RestClient.create();
+
+    @Value("${apple.issuer}")
+    private String issuer;
+
+    @Value("${apple.client-id}")
+    private String clientId;
+
+    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
+
+    private final ObjectMapper objectMapper;
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    public AppleUserInfoResponseDTO getAppleUserInfo(String identityToken) throws
+            IOException,
+            NoSuchAlgorithmException,
+            InvalidKeySpecException, AuthenticationException, InterruptedException, org.apache.http.auth.AuthenticationException {
+
+        // jwt 헤더를 파싱한다.
+        Map<String, String> headers = jwtValidator.parseHeaders(identityToken);
+
+        // 공개키를 생성한다
+        PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, getAppleAuthPublicKey());
+
+        // 공개 키를 사용해 토큰의 서명을 검사하고 Claim을 반환받는다.
+        Claims tokenClaims = jwtValidator.getTokenClaims(identityToken, publicKey);
+
+        log.info("headers: {}", headers);
+        log.info("tokenClaims: {}", tokenClaims);
+
+        verifyIdentityToken(tokenClaims);
+        AppleUserInfoResponseDTO response = objectMapper.convertValue(tokenClaims, AppleUserInfoResponseDTO.class);
+
+        return response;
+    }
+
+    private void verifyIdentityToken(Claims tokenClaims) {
+        if (!issuer.equals(tokenClaims.getIssuer()))
+            throw new MalformedJwtException("Invalid JWT");
+
+        if (!clientId.equals(tokenClaims.getAudience()))
+            throw new MalformedJwtException("Invalid JWT");
+    }
+
+    private ApplePublicKeyResponse getAppleAuthPublicKey() throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(APPLE_PUBLIC_KEYS_URL))
+                .GET()
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() == 200) {
+            return objectMapper.readValue(response.body(), ApplePublicKeyResponse.class);
+        } else {
+            throw new RuntimeException("Failed to retrieve Apple public keys. Status code: " + response.statusCode());
+        }
+    }
+
+    public String getAppleRefreshToken(String authorizationCode) throws IOException {
+        log.info("getAppleRefreshToken authorizationCode: {}", authorizationCode);
+        MultiValueMap<String, String> body = getCreateTokenBody(authorizationCode);
+
+        log.info("Request Body: {}", body);
+
+        AppleTokenResponse appleTokenResponse = restClient.post()
+                .uri("https://appleid.apple.com/auth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .body(AppleTokenResponse.class);
+
+        return Objects.requireNonNull(appleTokenResponse).getRefresh_token();
+    }
+
+    private MultiValueMap<String, String> getCreateTokenBody(String authorizationCode) throws IOException {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        body.add("client_id", clientId);
+        body.add("client_secret", appleKeyGenerator.getClientSecret());
+        body.add("grant_type", "authorization_code");
+        return body;
+    }
+
+    public void revokeToken(String refreshToken) throws IOException {
+        MultiValueMap<String, String> body = getRevokeTokenBody(refreshToken);
+
+        restClient.post()
+                .uri("https://appleid.apple.com/auth/revoke")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    private MultiValueMap<String, String> getRevokeTokenBody(String refreshToken) throws IOException {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", clientId);
+        body.add("token", refreshToken);
+        body.add("client_secret", appleKeyGenerator.getClientSecret());
+        body.add("token_type_hint", "refresh_token");
+        return body;
+    }
+}

--- a/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
+++ b/demo/src/main/java/com/example/demo/oauth2/controller/Oauth2Controller.java
@@ -2,6 +2,7 @@ package com.example.demo.oauth2.controller;
 
 import com.example.demo.member.service.MemberRegistryService;
 import com.example.demo.oauth2.apple.dto.AppleLoginDTO;
+import com.example.demo.oauth2.apple.dto.AppleRevokeDTO;
 import com.example.demo.oauth2.apple.dto.AppleUserInfoResponseDTO;
 import com.example.demo.oauth2.apple.service.AppleService;
 import com.example.demo.oauth2.dto.ReissueDTO;
@@ -71,12 +72,12 @@ public class Oauth2Controller {
         return ResponseEntity.status(200).body(loginResponse);
     }
 
-//    @GetMapping("/shared/apple/logout")
-//    @Operation(summary = "[공통] 애플 로그아웃")
-//    public ResponseEntity<Void> appleLogout() {
-//        appleService.logout();
-//        return ResponseEntity.status(200).build();
-//    }
+    @GetMapping("/shared/apple/revoke")
+    @Operation(summary = "[공통] 애플 탈퇴")
+    public ResponseEntity<Void> appleLogout(@RequestBody AppleRevokeDTO revokeRequest) throws IOException {
+        memberRegistryService.logout(revokeRequest);
+        return ResponseEntity.status(200).build();
+    }
 
     @PostMapping("/shared/reissue")
     @Operation(summary = "[공통] 리프레시 토큰(RT)을 통한 AT,RT 재발급")

--- a/demo/src/main/java/com/example/demo/redis/service/RedisService.java
+++ b/demo/src/main/java/com/example/demo/redis/service/RedisService.java
@@ -134,6 +134,21 @@ public class RedisService {
         }
     }
 
+    // delete all value from all Value
+    public void deleteValueFromAllValue(String value) {
+        // Get all keys that match the pattern "*"
+        Set<String> allKeys = redisTemplate.keys("*");
+
+        // Iterate over all keys
+        for (String key : allKeys) {
+            // Check if the value exists in the set associated with this key
+            if (redisTemplate.opsForValue().get(key).equals(value)) {
+                redisTemplate.delete(key);
+            }
+        }
+    }
+
+
     // get all keys and their corresponding set members
     public Map<String, Set<Object>> getAllSetPairs() {
         Set<String> allKeys = redisTemplate.keys("*");  // get all keys

--- a/demo/src/main/resources/application.yml
+++ b/demo/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
         options:
           model: gpt-3.5-turbo
           temperature: 0.5
-
+        
 discord:
   customer-service: discord-customer-service
   exception: discord-exception
@@ -43,6 +43,14 @@ kakao:
 google:
   client-id-android: ${GOOGLE_CLIENT_ID_ANDROID}}
   client-id-ios: ${GOOGLE_CLIENT_ID_IOS}
+
+apple:
+  issuer: https://appleid.apple.com
+  client-id: ${APPLE_CLIENT_ID}
+  team-id: ZLC7FQLLD8
+  private-key: ${APPLE_PRIVATE_KEY}
+  app-id: com.dears.dears
+  kid: ${APPLE_KID}
 
 ---
 

--- a/demo/src/test/java/com/example/demo/chat/service/MessageServiceTest.java
+++ b/demo/src/test/java/com/example/demo/chat/service/MessageServiceTest.java
@@ -1,0 +1,84 @@
+package com.example.demo.chat.service;
+
+import com.example.demo.chat.dto.MessageDTO;
+import com.example.demo.chat.repository.ChatRoomRepository;
+import com.example.demo.config.S3Uploader;
+import com.example.demo.enums.chat.MessageType;
+import com.example.demo.enums.member.MemberRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertNotNull;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class MessageServiceTest {
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private MessageService messageService;
+
+    @MockBean
+    private S3Uploader s3Uploader;
+
+    @Test
+    @DisplayName("메시지 전송 테스트")
+    public void testMessageDelivery() throws Exception {
+        WebSocketStompClient stompClient = new WebSocketStompClient(new SockJsClient(createTransportClient()));
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        StompSessionHandlerAdapter sessionHandler = new StompSessionHandlerAdapter() {
+        };
+        StompSession session = stompClient.connect("ws://127.0.0.1:8080/stomp/chat/900/iz5furmk/websocket", sessionHandler).get(1, TimeUnit.SECONDS);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<MessageDTO.Response> receivedMessage = new AtomicReference<>();
+
+        session.subscribe("/sub/1", new StompFrameHandler() {
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+                return MessageDTO.Response.class;
+            }
+
+            @Override
+            public void handleFrame(StompHeaders headers, Object payload) {
+                receivedMessage.set((MessageDTO.Response) payload);
+                latch.countDown();
+            }
+        });
+
+        session.send("/pub/1", new MessageDTO.Request(MemberRole.CUSTOMER, MessageType.SEND, "test", 1L));
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertNotNull(receivedMessage.get());
+    }
+
+    private List<Transport> createTransportClient() {
+        return Collections.singletonList(new WebSocketTransport(new StandardWebSocketClient()));
+    }
+
+
+}


### PR DESCRIPTION
### PR 요약
애플 로그인/회원탈퇴 구현

### 변경 사항
- 애플 공개 키 생성을 위한 AppleKeyGenerator 구현
- JWT 검증 방식을 비밀 키에서 공개 키로 변경
- 애플 리프레시 토큰을 저장하기 위한 AppleRefreshToken 엔티티 추가
- 유효한 토큰 클레임을 이용해 애플 사용자 정보 가져오기 기능 구현
- 로그인 시 애플 사용자에 대한 멤버 역할 분기 로직 추가
- 애플 관련 설정 및 발급 관련 코드 추가

### 참고 사항
![image](https://github.com/user-attachments/assets/eac029f7-3696-49c7-a972-5c66c79b4cc5)
