### PR TITLE
Fix/Resolve authentication issue with token validation

### DIFF
--- a/demo/src/main/java/com/teamdears/core/config/JwtAuthenticationFilter.java
+++ b/demo/src/main/java/com/teamdears/core/config/JwtAuthenticationFilter.java
@@ -3,9 +3,6 @@ package com.teamdears.core.config;
 import com.teamdears.core.error.custom.InvalidJwtAuthenticationException;
 import com.teamdears.core.jwt.JwtValidator;
 import com.teamdears.core.member.service.CustomUserDetailsService;
-import com.teamdears.core.oauth2.apple.dto.ApplePublicKeyResponse;
-import com.teamdears.core.oauth2.apple.service.ApplePublicKeyGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -17,18 +14,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.security.PublicKey;
-import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -37,35 +30,44 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final CustomUserDetailsService customUserDetailsService;
     private final JwtValidator jwtValidator;
-    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-
         String accessToken = resolveToken(request);
 
         try {
-            if (accessToken != null) {
-                // JWT 헤더를 파싱하고 공개 키를 가져옴
-                Map<String, String> headers = jwtValidator.parseHeaders(accessToken);
-                PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, getAppleAuthPublicKey());
-
-                // 공개 키로 서명 검증
-                if (jwtValidator.isValidToken(accessToken, publicKey)) {
-                    Authentication authentication = getAuthentication(accessToken, publicKey);
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                }
+            log.info("accessToken: {}", accessToken);
+            // validate JWT token
+            if (accessToken != null && jwtValidator.isValidToken(accessToken)) {
+                log.info("accessToken is valid");
+                Authentication authentication = getAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (InvalidJwtAuthenticationException e) {
             log.error("Invalid JWT token: {}", e.getMessage());
             SecurityContextHolder.clearContext();
+
             response.sendError(HttpStatus.UNAUTHORIZED.value(), "Invalid JWT signature");
             return;
-        } catch (Exception e) {
-            logger.error("Could not set user authentication in security context", e);
+        }
+
+        if (StringUtils.hasText(accessToken)) {
+            try {
+                // load user by JWT access token
+                UserDetails userDetails = customUserDetailsService.loadUserByAccessToken(accessToken);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                logger.error("Could not set user authentication in security context", e);
+            }
         }
 
         filterChain.doFilter(request, response);
@@ -79,30 +81,30 @@ class JwtAuthenticationFilter extends OncePerRequestFilter {
         return null;
     }
 
-    private Authentication getAuthentication(String token, PublicKey publicKey) {
-        // 공개 키를 사용하여 토큰에서 사용자 정보 추출 및 인증 객체 생성
-        Claims claims = jwtValidator.getTokenClaims(token, publicKey);
+    private Authentication getAuthentication(String token) {
+        // 토큰에서 사용자 정보 추출 및 인증 객체 생성
+        Claims claims = jwtValidator.getTokenClaims(token);
         String username = claims.getSubject();
         // 권한 또는 사용자 정보 설정
         return new UsernamePasswordAuthenticationToken(username, null, new ArrayList<>());
     }
 
-    private ApplePublicKeyResponse getAppleAuthPublicKey() throws IOException, InterruptedException {
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("https://appleid.apple.com/auth/keys"))
-                .GET()
-                .build();
-
-        HttpResponse<String> response = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .build()
-                .send(request, HttpResponse.BodyHandlers.ofString());
-
-        if (response.statusCode() == 200) {
-            ObjectMapper objectMapper = new ObjectMapper();
-            return objectMapper.readValue(response.body(), ApplePublicKeyResponse.class);
-        } else {
-            throw new RuntimeException("Failed to retrieve Apple public keys. Status code: " + response.statusCode());
-        }
-    }
+//    private ApplePublicKeyResponse getAppleAuthPublicKey() throws IOException, InterruptedException {
+//        HttpRequest request = HttpRequest.newBuilder()
+//                .uri(URI.create("https://appleid.apple.com/auth/keys"))
+//                .GET()
+//                .build();
+//
+//        HttpResponse<String> response = HttpClient.newBuilder()
+//                .connectTimeout(Duration.ofSeconds(10))
+//                .build()
+//                .send(request, HttpResponse.BodyHandlers.ofString());
+//
+//        if (response.statusCode() == 200) {
+//            ObjectMapper objectMapper = new ObjectMapper();
+//            return objectMapper.readValue(response.body(), ApplePublicKeyResponse.class);
+//        } else {
+//            throw new RuntimeException("Failed to retrieve Apple public keys. Status code: " + response.statusCode());
+//        }
+//    }
 }

--- a/demo/src/main/java/com/teamdears/core/error/ErrorCode.java
+++ b/demo/src/main/java/com/teamdears/core/error/ErrorCode.java
@@ -51,7 +51,7 @@ public enum ErrorCode {
     NOT_FOUND_ERROR(404, "G009", "Not Found Exception"),
 
     // NULL Point Exception 발생
-    NULL_POINT_ERROR(404, "G010", "Null Point Exception"),
+    NULL_POINT_ERROR(404, "G010", "Null Pointer Exception"),
 
     // @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
     NOT_VALID_ERROR(404, "G011", "handle Validation Exception"),

--- a/demo/src/main/java/com/teamdears/core/jwt/TokenProvider.java
+++ b/demo/src/main/java/com/teamdears/core/jwt/TokenProvider.java
@@ -9,8 +9,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -22,9 +21,8 @@ import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class TokenProvider implements InitializingBean {
-    private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
-
     private static final long ACCESS_TOKEN_VALIDITY_SECONDS_TEST = 60; // 테스트용 AT는 1분
     private static final long REFRESH_TOKEN_VALIDITY_SECONDS_TEST = 10; // 테스트용 RT는 1분
     private static final long ACCESS_TOKEN_VALIDITY_SECONDS = 24 * 60 * 60; // access token은 24시간
@@ -51,15 +49,15 @@ public class TokenProvider implements InitializingBean {
             System.out.println("claims.getSubject() = " + claims.getSubject());
             return claims.getSubject();
         } catch (SignatureException ex) {
-            logger.error("Invalid JWT signature");
+            log.error("Invalid JWT signature");
         } catch (MalformedJwtException ex) {
-            logger.error("Invalid JWT token");
+            log.error("Invalid JWT token");
         } catch (ExpiredJwtException ex) {
-            logger.error("Expired JWT token");
+            log.error("Expired JWT token");
         } catch (UnsupportedJwtException ex) {
-            logger.error("Unsupported JWT token");
+            log.error("Unsupported JWT token");
         } catch (IllegalArgumentException ex) {
-            logger.error("JWT claims string is empty.");
+            log.error("JWT claims string is empty.");
         }
         return null;
     }
@@ -122,13 +120,13 @@ public class TokenProvider implements InitializingBean {
             Jwts.parser().setSigningKey(key).parseClaimsJws(accessToken);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            logger.info("잘못된 JWT 서명입니다.");
+            log.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
-            logger.info("만료된 JWT 토큰입니다.");
+            log.info("만료된 JWT 토큰입니다.");
         } catch (UnsupportedJwtException e) {
-            logger.info("지원되지 않는 JWT 토큰입니다.");
+            log.info("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {
-            logger.info("JWT 토큰이 잘못되었습니다.");
+            log.info("JWT 토큰이 잘못되었습니다.");
         }
         return false;
     }
@@ -138,13 +136,13 @@ public class TokenProvider implements InitializingBean {
             Jwts.parser().setSigningKey(key).parseClaimsJws(refreshToken);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            logger.info("잘못된 JWT 서명입니다.");
+            log.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
-            logger.info("만료된 JWT 토큰입니다.");
+            log.info("만료된 JWT 토큰입니다.");
         } catch (UnsupportedJwtException e) {
-            logger.info("지원되지 않는 JWT 토큰입니다.");
+            log.info("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {
-            logger.info("JWT 토큰이 잘못되었습니다.");
+            log.info("JWT 토큰이 잘못되었습니다.");
         }
         return false;
     }

--- a/demo/src/main/java/com/teamdears/core/member/controller/MemberController.java
+++ b/demo/src/main/java/com/teamdears/core/member/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.teamdears.core.member.controller;
 
-import com.teamdears.core.member.dto.AuthDTO;
 import com.teamdears.core.member.dto.MypageDTO;
 import com.teamdears.core.member.service.CustomUserDetailsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,14 +17,6 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final CustomUserDetailsService customUserDetailsService;
-    
-    @PostMapping("/auth/shared/create")
-    @Operation(summary = "[공통] 토큰이 없을 때 유저 생성", description = "CUSTOMER 또는 WEDDING_PLANNER로 권한을 요청합니다.")
-    public ResponseEntity<AuthDTO.Response> createMember(@RequestBody AuthDTO.Request customerAuthRequest) {
-        AuthDTO.Response createdMember = customUserDetailsService.join(customerAuthRequest.getRole());
-        log.info("Created new member with role: {}", customerAuthRequest.getRole());
-        return ResponseEntity.status(201).body(createdMember);
-    }
 
     @GetMapping("/mypage/customer/me")
     @Operation(summary = "[신랑신부] 마이페이지 조회", description = "토큰을 통해 마이페이지 정보를 조회합니다.")

--- a/demo/src/main/resources/static/index.html
+++ b/demo/src/main/resources/static/index.html
@@ -2,11 +2,59 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dears</title>
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .landing-container {
+            position: relative;
+            text-align: center;
+        }
+
+        .landing-image {
+            max-width: 100%;
+            height: auto;
+        }
+
+        .store-buttons {
+            position: absolute;
+            bottom: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+        }
+
+        .store-buttons a {
+            margin: 0 10px;
+        }
+
+        .store-buttons img {
+            width: 150px;
+            height: auto;
+        }
+    </style>
 </head>
 <body>
-<p>
-    dears-test
-</p>
+<div class="landing-container">
+    <!-- 랜딩 이미지 -->
+    <img src="../imgs/landing-page.png" alt="Landing Image" class="landing-image">
+
+    <!-- 구글 플레이, 앱스토어 버튼 -->
+    <div class="store-buttons">
+        <a href="https://play.google.com/store" target="_blank">
+            <img src="google-play-button.png" alt="Google Play">
+        </a>
+        <a href="https://apps.apple.com/" target="_blank">
+            <img src="app-store-button.png" alt="App Store">
+        </a>
+    </div>
+</div>
 </body>
 </html>


### PR DESCRIPTION
### PR 요약
유효한 토큰에도 `401 UNAUTHORIZED` 에러를 발생하는 이슈 해결

### 변경 사항
- `JwtAuthenticationFilter`에서 `accessToken`과 `publicKey `를 이용하여 인증 처리하는 것에서 문제 발생
- 애플 로그인 구현 이전처럼 `accessToken` 만 이용하여 인증 처리하도록 롤백
- 유효하지 않은 토큰(변조)에는 여전히 `401 UNAUTHORIZED` 를 반환하지만, 서로 다른 ROLE의 리소스를 요청하는 상황에는 404 등 적합하지 않은 에러코드가 반환됨.
- 프론트에서 앞단 분기를 잘 한다면 서로 다른 ROLE의 API 및 리소스 접근은 불가능하다고 판단하여 refix 보류

### 참고 사항
- #181 