### PR TITLE
Refactor/Block blacklisted ip list

### DIFF
--- a/demo/.platform/nginx/nginx.conf
+++ b/demo/.platform/nginx/nginx.conf
@@ -31,6 +31,13 @@ http {
   server {
       listen        80 default_server;
 
+      # BLACK LIST
+      deny 172.31.12.221;
+      deny 93.123.85.155;
+      deny 142.93.10.107;
+
+      allow all;
+
       location / {
           proxy_pass          http://springboot;
           proxy_http_version  1.1;
@@ -43,14 +50,14 @@ http {
       }
 
       location /metrics {
-        proxy_pass          http://127.0.0.1:9100/metrics;
-        proxy_http_version  1.1;
+          proxy_pass          http://127.0.0.1:9100/metrics;
+          proxy_http_version  1.1;
 
-        proxy_set_header    Connection          $connection_upgrade;
-        proxy_set_header    Upgrade             $http_upgrade;
-        proxy_set_header    Host                $host;
-        proxy_set_header    X-Real-IP           $remote_addr;
-        proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+          proxy_set_header    Connection          $connection_upgrade;
+          proxy_set_header    Upgrade             $http_upgrade;
+          proxy_set_header    Host                $host;
+          proxy_set_header    X-Real-IP           $remote_addr;
+          proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
       }
 
       access_log    /var/log/nginx/access.log main;


### PR DESCRIPTION
### PR 요약
어플리케이션 스캔 대응하기 위해, WAF 뚫고 꾸준히 들어오는 IP 추적하여 블락합니다.

### 논의 사항
어플리케이션 스캔으로 인해 LB 비용이 가장 많이 나옵니다.
Nginx 이전에 더 앞단에서 블락할 수 있는지 아이디어 있으면 알려주세요!

### 참고 사항
우리 EB EC2에서 아래 커맨드로 IP 및 타임스탬프 확인할 수 있습니다.
`tail -n 100 /var/log/nginx/access.log | awk '{print $1, $4, $7}'`


![image](https://github.com/user-attachments/assets/f8d6ada8-ff5c-4006-b32a-41ef622e453e)
